### PR TITLE
README.md: use a version shield

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
-[![Dub package](https://img.shields.io/badge/dub-package-FF4081.svg)](http://code.dlang.org/packages/mir)
+[![Dub version](https://img.shields.io/dub/v/mir.svg)](http://code.dlang.org/packages/mir)
 [![Build Status](https://travis-ci.org/DlangScience/mir.svg?branch=master)](https://travis-ci.org/DlangScience/mir)
 [![codecov.io](https://codecov.io/github/DlangScience/mir/coverage.svg?branch=master)](https://codecov.io/github/DlangScience/mir?branch=master)
+[![License](https://img.shields.io/dub/l/mir.svg)](http://code.dlang.org/packages/mir)
+[![Dub downloads](https://img.shields.io/dub/dt/mir.svg)](http://code.dlang.org/packages/mir)
 [![Join the chat at https://gitter.im/DlangScience/public](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/DlangScience/public?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
 Mir


### PR DESCRIPTION
Might be nice to show the latest version instead.
There are a lot more shields for dub. 

http://shields.io/

Another good one is total downloads.

https://img.shields.io/dub/dt/mir.svg

However I don't know whether you want to show this while it is still low.

![Total downloads](https://img.shields.io/dub/dt/mir.svg)
