### PR TITLE
ndslice.slice: improve coverage

### DIFF
--- a/source/mir/ndslice/slice.d
+++ b/source/mir/ndslice/slice.d
@@ -290,12 +290,15 @@ pure nothrow @nogc unittest
     }
 
     alias S = Slice!(3, MyIota);
-    auto slice = MyIota().sliced(20, 10);
 
     import std.range.primitives;
     static assert(hasLength!S);
     static assert(isInputRange!S);
     static assert(isForwardRange!S == false);
+
+    auto slice = MyIota().sliced(20, 10);
+    assert(slice[1, 2] == 12);
+
 }
 
 /// Random access range primitives for slices over user defined types
@@ -316,14 +319,17 @@ pure nothrow @nogc unittest
     }
 
     alias S = Slice!(3, MyIota);
-    auto slice = MyIota().sliced(20, 10);
-
     import std.range.primitives;
     static assert(hasLength!S);
     static assert(hasSlicing!S);
     static assert(isForwardRange!S);
     static assert(isBidirectionalRange!S);
     static assert(isRandomAccessRange!S);
+
+    auto slice = MyIota().sliced(20, 10);
+    assert(slice[1, 2] == 12);
+    auto sCopy = slice.save;
+    assert(slice[1, 2] == 12);
 }
 
 ///


### PR DESCRIPTION
The `index` and `save` methods here are never called.

This might be a bit controversial - so I separated it.
