### PR TITLE
mir.random: initial API

### DIFF
--- a/source/mir/random/package.d
+++ b/source/mir/random/package.d
@@ -1,0 +1,182 @@
+/**
+Random number generators.
+
+Authors: Sebastian Wilzbach, Ilya Yaroshenko
+
+License: $(LINK2 http://boost.org/LICENSE_1_0.txt, Boost License 1.0).
+*/
+module mir.random;
+
+import std.random: rndGen, Random, uniform;
+import mir.ndslice.slice: Slice;
+
+/*
+Checks whether a type is Slice.
+/**/
+template isSlice(T)
+{
+    import std.traits: TemplateOf;
+    enum bool isSlice = __traits(compiles, __traits(isSame, TemplateOf!(T), Slice));
+}
+
+// init distribution with random method and args
+auto rinit(alias Random, T, Args...)(T arr, Args args)
+if (!isSlice!T)
+{
+    foreach (ref el; arr)
+    {
+        el = Random(args);
+    }
+    return arr;
+}
+
+// init slice distribution
+auto rinit(alias Random, size_t N, Range, Args...)(auto ref Slice!(N, Range) slice, Args args)
+{
+    import mir.ndslice.selection: byElement;
+    auto il = byElement(slice);
+    rinit!Random(il, args);
+    return slice;
+}
+
+// allocate and build distribution with args
+auto rarray(alias Random, size_t, Args...)(size_t n, Args args)
+{
+    import std.traits : ReturnType;
+    //alias T = ReturnType!(Random.init.front);
+    alias T = uint;
+    T[] arr = new T[n];
+    return rinit!Random(arr, args);
+}
+
+unittest
+{
+    import mir.ndslice.slice: slice;
+    rndGen.seed(42);
+
+    assert(rarray!bernoulli(10, 0.5) == [1, 0, 0, 1, 0, 0, 0, 0, 1, 1]);
+    assert(rarray!bernoulli(10, 0.5, rndGen) == [1, 1, 1, 1, 0, 1, 0, 1, 0, 0]);
+
+    auto arr = new int[10];
+    assert(rinit!bernoulli(arr, 0.5) == [1, 1, 1, 1, 0, 1, 0, 1, 0, 0]);
+    assert(rinit!bernoulli(slice!int(2, 5), 0.5) == [[1, 1, 0, 0, 0], [0, 1, 1, 1, 0]]);
+}
+
+auto randRange(alias Random, Args...)(Args args)
+{
+    static struct RandRange
+    {
+        Args args;
+        static bool empty = false;
+
+        this(Args args)
+        {
+            this.args = args;
+        }
+
+        ///
+        auto front() @property
+        {
+            return Random(args);
+        }
+
+        ///
+        void popFront() @safe pure nothrow @nogc
+        {
+            // TODO
+        }
+
+        ///
+        typeof(this) save() @safe pure nothrow @nogc
+        {
+            return this;
+        }
+
+        ///
+        //bool opEquals()(auto ref const typeof(this) y) const pure nothrow @safe @nogc
+        //{
+           //return p == y.p;
+        //}
+
+        void reset()
+        {
+
+        }
+    }
+    return RandRange(args);
+}
+
+// support ranges
+@safe unittest
+{
+    import std.algorithm: equal;
+    import std.range: takeExactly;
+
+    rndGen.seed(42);
+
+    auto range = randRange!bernoulli(0.5);
+    assert(range.takeExactly(10).equal([1, 0, 0, 1, 0, 0, 0, 0, 1, 1]));
+}
+
+uint bernoulli(RGen)(double p = 0.5, ref RGen gen = rndGen)
+{
+    assert(0 <= p && p <= 1, "Invalid probability");
+    auto val = uniform(0.0L, 1.0L, gen);
+    return cast(uint) (val <= p);
+}
+
+unittest
+{
+    import mir.stat: stat;
+    import std.range: takeExactly;
+
+    auto range = randRange!bernoulli(0.5).takeExactly(10_000);
+    import std.math: approxEqual;
+    assert(approxEqual(range.stat.mean, 0.5, 0.1));
+    assert(approxEqual(range.stat.var, 0.25, 0.1));
+}
+
+/*
+WIP - Currently only
+$(WEB https://en.wikipedia.org/wiki/Box%E2%80%93Muller_transform, Box Muller-transform)
+References:
+    Butcher, J. C. "Random sampling from the normal distribution."
+    The Computer Journal 3.4 (1961): 251-253.
+    http://comjnl.oxfordjournals.org/content/3/4/251.full.pdf
+*/
+auto normal(RGen)(double mu, double sigma, ref RGen gen = rndGen)
+{
+    import std.math: PI, log, cos, sin, sqrt;
+    static double epsilon = double.min_normal;
+	static double two_pi = 2.0 * PI;
+
+	static double z0, z1;
+	static bool generate;
+	generate = !generate;
+
+	if (!generate)
+	   return z1 * sigma + mu;
+
+	double u1, u2;
+	do
+	 {
+	   u1 = uniform(0.0L, 1.0L, gen);
+	   u2 = uniform(0.0L, 1.0L, gen);
+	 }
+	while ( u1 <= epsilon );
+
+	z0 = sqrt(-2.0 * log(u1)) * cos(two_pi * u2);
+	z1 = sqrt(-2.0 * log(u1)) * sin(two_pi * u2);
+	return z0 * sigma + mu;
+}
+
+unittest
+{
+    import std.range: takeExactly;
+    import mir.stat: stat;
+
+    auto range = randRange!normal(0, 1).takeExactly(100_000);
+    import std.math: approxEqual;
+    assert(range.stat.mean.approxEqual(0.0, 1e-2, 1e-2));
+    assert(range.stat.var.approxEqual(1.0, 0.1));
+}

--- a/source/mir/stat/package.d
+++ b/source/mir/stat/package.d
@@ -1,0 +1,209 @@
+/**
+Statistical functions
+
+License: $(LINK2 http://boost.org/LICENSE_1_0.txt, Boost License 1.0).
+*/
+
+module mir.stat;
+
+import std.range: isInputRange, isInfinite;
+import std.range;
+
+/**
+Cumulative computation of mean and variance of an observed distribution.
+
+Params:
+    rs = InputRange of observed elements
+
+Returns:
+    $(LREF StatReport) with the observed mean and variance
+*/
+StatReport!R stat(R)(R rs)
+if (isInputRange!R && !isInfinite!R)
+{
+    return StatReport!R(rs);
+}
+
+/**
+$(WEB https://en.wikipedia.org/wiki/Algorithms_for_calculating_variance#Online_algorithm, Online)
+statistical report about mean and variance as an OutputRange.
+It computes the mean and variance.
+
+See_Also:
+    $(LREF stat)
+*/
+struct StatReport(R)
+if (isInputRange!R && !isInfinite!R)
+{
+import std.range: ElementType;
+
+alias E = ElementType!R;
+alias FType = double;
+
+private:
+    ulong _nrs = 0;
+    FType _mean = 0;
+    FType _m2 = 0;
+
+public:
+
+    ///
+    this(ref R rs)
+    {
+        put(rs);
+    }
+
+    /// Knuth & Welford online-update
+    void put(FType x)
+    {
+        const auto delta = (x - _mean);
+        this._mean += delta / ++_nrs;
+        this._m2 += delta * (x - mean);
+    }
+
+    /// Knuth & Welford online-update
+    void put(T)(auto ref T rs)
+    if (isInputRange!T && !isInfinite!T)
+    {
+        foreach (r; rs)
+        {
+            put(r);
+        }
+    }
+
+    /** Online combine after
+    $(WEB http://i.stanford.edu/pub/cstr/reports/cs/tr/79/773/CS-TR-79-773.pdf, Chain et. al)
+    **/
+    void put(A)(auto ref A rs)
+    if (is(typeof(A.mean + A.nrs + A._m2)))
+    {
+        import std.math: pow;
+        const auto rsnrs = rs.nrs;
+        const auto nx = _nrs + rsnrs;
+        const auto delta = rs.mean - _mean;
+        _mean += delta * rsnrs / nx;
+        _m2 = _m2 + rs._m2 + pow(delta, 2) * _nrs * rsnrs  / nx;
+        _nrs = nx;
+    }
+
+    ///
+    typeof(this) save()
+    {
+        return this;
+    }
+
+    /// Mean
+    auto mean()
+    {
+        return _mean;
+    }
+
+    /// Variance
+    auto var()
+    {
+        return (_nrs < 2) ? double.nan : _m2 / (_nrs - 1);
+    }
+
+    /// Sum of all observed elements
+    auto sum()
+    {
+        return _nrs * _mean;
+    }
+
+    /// Standard deviation
+    auto stddev()
+    {
+        import std.math: sqrt;
+        return sqrt(this.var);
+    }
+
+    /// Number of observed elements
+    auto nrs()
+    {
+        return _nrs;
+    }
+}
+
+///
+@safe pure nothrow @nogc unittest
+{
+    import std.range: iota;
+    import std.math: approxEqual;
+
+    assert(iota(11).stat.mean.approxEqual(5.0));
+    assert(iota(-10, 0).stat.mean.approxEqual(-5.5));
+
+    assert(iota(9).stat.var.approxEqual(7.5));
+    assert(iota(-10, 0).stat.var.approxEqual(9.1667));
+
+    assert(iota(11).stat.stddev.approxEqual(3.3166));
+    assert(iota(-10, 0).stat.stddev.approxEqual(3.02765));
+
+    assert(iota(10).stat.sum == 45);
+}
+
+@safe pure nothrow @nogc unittest
+{
+    import std.range: iota;
+    import std.math: approxEqual;
+
+    auto s1 = iota(4).stat;
+    assert(s1.nrs == 4);
+
+    s1.put(iota(4, 10).stat);
+    assert(s1.mean.approxEqual(4.5));
+    assert(s1.var.approxEqual(9.1667));
+
+    import std.range: isOutputRange;
+    static assert(isOutputRange!(typeof(s1), double));
+
+    auto s2 = iota(-10, -7).stat;
+    assert(s2.nrs == 3);
+
+    s2.put(iota(-7, 0).stat);
+    assert(s2.mean.approxEqual(-5.5));
+    assert(s1.var.approxEqual(9.1667));
+    assert(s2.nrs == 10);
+}
+
+// online update with high precision
+@safe pure nothrow @nogc unittest
+{
+    import std.range: iota, takeExactly, dropExactly;
+    import std.math: approxEqual;
+    import std.algorithm: map;
+
+    static immutable h = 1e14;
+
+    static immutable arr = [h + 4, h + 7, h + 13, h + 16];
+    assert(arr.stat.var.approxEqual(30, 0.0001));
+
+    auto arr2 = iota(10).map!(a => h + a);
+    auto s1 = arr2.takeExactly(4).stat;
+    assert(s1.nrs == 4);
+    assert(s1.var.approxEqual(1.6667, 0.01));
+
+    s1.put(arr2.dropExactly(4).stat);
+    assert(s1.var.approxEqual(9.1667));
+    assert(s1.nrs == 10);
+}
+
+// check "save"
+@safe pure nothrow @nogc unittest
+{
+    import std.range: iota;
+    import std.math: approxEqual;
+
+    auto s1 = iota(4).stat;
+    assert(s1.nrs == 4);
+    auto s1c = s1.save;
+    s1c.put(4);
+    s1c.put(iota(5, 9));
+    s1c.put(iota(9, 20).stat);
+
+    assert(s1.nrs == 4);
+    assert(s1c.nrs == 20);
+    assert(s1c.sum == 190);
+    assert(s1c.mean.approxEqual(9.5));
+    assert(s1c.var.approxEqual(35));
+}


### PR DESCRIPTION
Hey,

so I started to think (and play) with a new random API.
Please don't invest time looking over the code - it's just a draft and I want to use to ask better questions.
Update: only have a [lookat the unittest at the bottom](https://github.com/DlangScience/mir/pull/85/files#diff-a1906e86b965bd2806454874420b9c70R137)

Questions
1) Do we want methods to use a `struct` or just a `function` for the random generator methods? 
If you have a peek at [Boost::Random](https://github.com/boostorg/random), you will see that [`reset`](https://github.com/boostorg/random/blob/develop/include/boost/random/gamma_distribution.hpp#L155) is quite common. However [dstats](https://github.com/dsimcha/dstats/blob/master/source/dstats/random.d) avoids general states, but stores them if needed as a [singleton](https://github.com/dsimcha/dstats/blob/master/source/dstats/random.d#L485).

2) Do we want to save a reference to the random generator in such a struct?
The advantage is that when passing the reference, the struct is an usual infinite forward Range (see 3 too).

3) If the struct gets duplicates via `save` - should the random generator get duplicated too? A la

```
assert(randomMethod.front.approxEqual(0.786));
assert(randomMethod.save.dropOne.front.approxEqual(0.831));
assert(randomMethod.front.approxEqual(0.786));
```

4) The names are still horrible, but do you prefer to manual construction of a `struct` like `rarray(Bernoulli(0.5), 10)` or having a wrapper around it `rarray!Bernoulli(10, 0.5)` or both styles?
