### PR TITLE
add linting via dscanner

### DIFF
--- a/.dscanner.ini
+++ b/.dscanner.ini
@@ -1,0 +1,67 @@
+; Configurue which static analysis checks are enabled
+[analysis.config.StaticAnalysisConfig]
+; Check variable, class, struct, interface, union, and function names against t
+; he Phobos style guide
+style_check="false"
+; Check for array literals that cause unnecessary allocation
+enum_array_literal_check="true"
+; Check for poor exception handling practices
+exception_check="true"
+; Check for use of the deprecated 'delete' keyword
+delete_check="true"
+; Check for use of the deprecated floating point operators
+float_operator_check="true"
+; Check number literals for readability
+number_style_check="true"
+; Checks that opEquals, opCmp, toHash, and toString are either const, immutable
+; , or inout.
+object_const_check="true"
+; Checks for .. expressions where the left side is larger than the right.
+backwards_range_check="true"
+; Checks for if statements whose 'then' block is the same as the 'else' block
+if_else_same_check="true"
+; Checks for some problems with constructors
+constructor_check="true"
+; Checks for unused variables and function parameters
+unused_variable_check="false"
+; Checks for unused labels
+unused_label_check="true"
+; Checks for duplicate attributes
+duplicate_attribute="true"
+; Checks that opEquals and toHash are both defined or neither are defined
+opequals_tohash_check="true"
+; Checks for subtraction from .length properties
+length_subtraction_check="true"
+; Checks for methods or properties whose names conflict with built-in propertie
+; s
+builtin_property_names_check="true"
+; Checks for confusing code in inline asm statements
+asm_style_check="true"
+; Checks for confusing logical operator precedence
+logical_precedence_check="false"
+; Checks for undocumented public declarations
+undocumented_declaration_check="true"
+; Checks for poor placement of function attributes
+function_attribute_check="true"
+; Checks for use of the comma operator
+comma_expression_check="true"
+; Checks for local imports that are too broad
+local_import_check="false"
+; Checks for variables that could be declared immutable
+could_be_immutable_check="false"
+; Checks for redundant expressions in if statements
+redundant_if_check="true"
+; Checks for redundant parenthesis
+redundant_parens_check="true"
+; Checks for mismatched argument and parameter names
+mismatched_args_check="true"
+; Checks for labels with the same name as variables
+label_var_same_name_check="false"
+; Checks for lines longer than 120 characters
+long_line_check="true"
+; Checks for assignment to auto-ref function parameters
+auto_ref_assignment_check="true"
+; Checks for incorrect infinite range definitions
+incorrect_infinite_range_check="true"
+; Checks for asserts that are always true
+useless_assert_check="true"

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,9 +11,13 @@ d:
  - ldc-1.0.0-alpha1
  - ldc-0.17.0
 install:
+ - if [[ $(dmd --help | head -n 1 | cut -d ' ' -f 4) == 'v2.071.0' && $TRAVIS_OS_NAME == 'linux' ]] ; then export IS_LATEST_PHOBOS=1 ; fi
  - wget -O doveralls "https://github.com/ColdenCullen/doveralls/releases/download/v1.2.0/doveralls_linux_travis"
  - chmod +x doveralls
+ - wget -O dscanner "http://releases.dlang.io/dscanner/0.3.0-git/dscanner"
+ - chmod +x dscanner
 script:
+ - if [ "$IS_LATEST_PHOBOS" ] ; then ./dscanner --config .dscanner.ini --styleCheck source 2> /dev/null ; else echo "NOT_LATEST"; fi
  - dub test -b unittest-cov
 after_success:
  - bash <(curl -s https://codecov.io/bash)
@@ -37,7 +41,7 @@ deploy:
     on:
       branch: master
       repo: DlangScience/mir
-      condition: "$(dmd --help | head -n 1 | cut -d ' ' -f 4) == 'v2.070.2' && $TRAVIS_OS_NAME == 'linux'"
+      condition: "$IS_LATEST_PHOBOS"
   - provider: s3
     access_key_id: AKIAIQO2FAQJAHV7ICTQ
     secret_access_key:
@@ -52,4 +56,4 @@ deploy:
     on:
       branch: master
       repo: DlangScience/mir
-      condition: "$(dmd --help | head -n 1 | cut -d ' ' -f 4) == 'v2.070.2' && $TRAVIS_OS_NAME == 'linux'"
+      condition: "$IS_LATEST_PHOBOS"

--- a/source/mir/las/sum.d
+++ b/source/mir/las/sum.d
@@ -13,8 +13,8 @@ module mir.las.sum;
 unittest
 {
     import std.algorithm.iteration: map;
-    auto ar = [1, 1e100, 1, -1e100].map!(a => a*10000);
-    const r = 20000;
+    auto ar = [1, 1e100, 1, -1e100].map!(a => a*10_000);
+    const r = 20_000;
     assert(r == ar.sum!(Summation.kbn));
     assert(r == ar.sum!(Summation.kb2));
     assert(r == ar.sum!(Summation.precise));
@@ -117,12 +117,12 @@ unittest
 
     //with integral promotion
     assert(sum([false, true, true, false, true]) == 3);
-    assert(sum(ubyte.max.repeat(100)) == 25500);
+    assert(sum(ubyte.max.repeat(100)) == 25_500);
 
     //The result may overflow
-    assert(uint.max.repeat(3).sum()           ==  4294967293U );
+    assert(uint.max.repeat(3).sum()           ==  4_294_967_293U );
     //But a seed can be used to change the summation primitive
-    assert(uint.max.repeat(3).sum(ulong.init) == 12884901885UL);
+    assert(uint.max.repeat(3).sum(ulong.init) == 12_884_901_885UL);
 
     //Floating point summation
     assert(sum([1.0, 2.0, 3.0, 4.0]) == 10);
@@ -176,7 +176,7 @@ nothrow @nogc unittest
     assert(N+N == e.sum()); //finite number
 }
 
-/// Moving mean 
+/// Moving mean
 unittest
 {
     class MovingAverage
@@ -185,7 +185,7 @@ unittest
         double[] circularBuffer;
         size_t frontIndex;
 
-        double avg() @property
+        double avg() @property const
         {
             return summator.sum() / circularBuffer.length;
         }
@@ -274,7 +274,7 @@ enum Summation
         "Adaptive Precision Floating-Point Arithmetic and Fast Robust Geometric Predicates", Jonathan Richard Shewchuk),
         $(LINK2 http://bugs.python.org/file10357/msum4.py, Mark Dickinson's post at bugs.python.org).
     +/
-    
+
     /+
     Precise summation function as msum() by Raymond Hettinger in
     <http://aspn.activestate.com/ASPN/Cookbook/Python/Recipe/393090>,
@@ -374,9 +374,9 @@ struct Summator(T, Summation summation)
         @disable this();
 
     static if(summation == Summation.pairwise)
-        enum bool fastPairwise = 
-            isFloatingPoint!F || 
-            isComplex!F || 
+        private enum bool fastPairwise =
+            isFloatingPoint!F ||
+            isComplex!F ||
             is(F : __vector(W[N]), W, size_t N);
             //false;
 
@@ -388,7 +388,8 @@ struct Summator(T, Summation summation)
         }
         else
         {
-            static assert(summation == Summation.kahan, "internal error in mir.las.sum.Summator: template constraints is broken.");
+            static assert(summation == Summation.kahan,
+                "internal error in mir.las.sum.Summator: template constraints is broken.");
             alias F = T;
         }
     }
@@ -500,7 +501,8 @@ struct Summator(T, Summation summation)
                 }
                 else
                 {
-                    if (!.isInfinity(cast(T)y) || partials.length > 1 && !signbit(l * partials[$-2]) && t == l)
+                    if (!.isInfinity(cast(T)y) ||
+                        ((partials.length > 1 && !signbit(l * partials[$-2])) && t == l))
                         return 0;
                 }
             }
@@ -917,7 +919,7 @@ public:
                         v[0xD] += r[0x1D];
                         v[0xE] += r[0x1E];
                         v[0xF] += r[0x1F];
-                        
+
                         v[0x0] += v[0x8];
                         v[0x1] += v[0x9];
                         v[0x2] += v[0xA];
@@ -926,12 +928,12 @@ public:
                         v[0x5] += v[0xD];
                         v[0x6] += v[0xE];
                         v[0x7] += v[0xF];
-                        
+
                         v[0x0] += v[0x4];
                         v[0x1] += v[0x5];
                         v[0x2] += v[0x6];
                         v[0x3] += v[0x7];
-                        
+
                         v[0x0] += v[0x2];
                         v[0x1] += v[0x3];
 
@@ -940,7 +942,7 @@ public:
                         r.popFrontExactly(0x20);
 
                         put(v[0x0]);
-                    }                    
+                    }
                     L: if (r.length >= 0x10)
                     {
                         v[0x0] = cast(F) r[0x0];
@@ -959,7 +961,7 @@ public:
                         v[0xD] = cast(F) r[0xD];
                         v[0xE] = cast(F) r[0xE];
                         v[0xF] = cast(F) r[0xF];
-                        
+
                         v[0x0] += v[0x8];
                         v[0x1] += v[0x9];
                         v[0x2] += v[0xA];
@@ -968,12 +970,12 @@ public:
                         v[0x5] += v[0xD];
                         v[0x6] += v[0xE];
                         v[0x7] += v[0xF];
-                        
+
                         v[0x0] += v[0x4];
                         v[0x1] += v[0x5];
                         v[0x2] += v[0x6];
                         v[0x3] += v[0x7];
-                        
+
                         v[0x0] += v[0x2];
                         v[0x1] += v[0x3];
 
@@ -1001,7 +1003,7 @@ public:
                         v[0x1] += v[0x5];
                         v[0x2] += v[0x6];
                         v[0x3] += v[0x7];
-                        
+
                         v[0x0] += v[0x2];
                         v[0x1] += v[0x3];
 
@@ -1017,7 +1019,7 @@ public:
                         v[0x1] = cast(F) r[0x1];
                         v[0x2] = cast(F) r[0x2];
                         v[0x3] = cast(F) r[0x3];
-                        
+
                         v[0x0] += v[0x2];
                         v[0x1] += v[0x3];
 
@@ -1031,7 +1033,7 @@ public:
                     {
                         v[0x0] = cast(F) r[0x0];
                         v[0x1] = cast(F) r[0x1];
-                        
+
                         v[0x0] += v[0x1];
 
                         r.popFrontExactly(2);
@@ -1041,7 +1043,7 @@ public:
                     if (r.length)
                     {
                         v[0x0] = cast(F) r[0x0];
-                        
+
                         put(v[0x0]);
                     }
                 }
@@ -1067,7 +1069,7 @@ public:
                         v[0xD] = cast(F) r[i++];
                         v[0xE] = cast(F) r[i++];
                         v[0xF] = cast(F) r[i++];
-                        
+
                         v[0x0] += v[0x8];
                         v[0x1] += v[0x9];
                         v[0x2] += v[0xA];
@@ -1076,12 +1078,12 @@ public:
                         v[0x5] += v[0xD];
                         v[0x6] += v[0xE];
                         v[0x7] += v[0xF];
-                        
+
                         v[0x0] += v[0x4];
                         v[0x1] += v[0x5];
                         v[0x2] += v[0x6];
                         v[0x3] += v[0x7];
-                        
+
                         v[0x0] += v[0x2];
                         v[0x1] += v[0x3];
 
@@ -1104,7 +1106,7 @@ public:
                         v[0x1] += v[0x5];
                         v[0x2] += v[0x6];
                         v[0x3] += v[0x7];
-                        
+
                         v[0x0] += v[0x2];
                         v[0x1] += v[0x3];
 
@@ -1120,7 +1122,7 @@ public:
                         v[0x1] = cast(F) r[i++];
                         v[0x2] = cast(F) r[i++];
                         v[0x3] = cast(F) r[i++];
-                        
+
                         v[0x0] += v[0x2];
                         v[0x1] += v[0x3];
 
@@ -1134,7 +1136,7 @@ public:
                     {
                         v[0x0] = cast(F) r[i++];
                         v[0x1] = cast(F) r[i++];
-                        
+
                         v[0x0] += v[0x1];
 
                         r.popFrontExactly(2);
@@ -1144,7 +1146,7 @@ public:
                     if (length - i)
                     {
                         v[0x0] = cast(F) r[i];
-                        
+
                         put(v[0x0]);
                     }
                 }
@@ -1371,7 +1373,7 @@ public:
     }
 
     ///Returns $(D Summator) with extended internal partial sums.
-    C opCast(C : Summator!(P, _summation), P, Summation _summation)()
+    C opCast(C : Summator!(P, _summation), P, Summation _summation)() const
         if (
             _summation == summation &&
             isMutable!C &&
@@ -1462,7 +1464,7 @@ public:
     $(D cast(C)) operator overloading. Returns $(D cast(C)sum()).
     See also: $(D cast)
     +/
-    C opCast(C)() if (is(Unqual!C == T))
+    C opCast(C)() const if (is(Unqual!C == T))
     {
         return cast(C)sum();
     }
@@ -1811,7 +1813,7 @@ nothrow unittest
         tuple([-2.^^-1074, -M, -M, 2.^^970], -double.infinity),
         tuple([2.^^930, -2.^^980, M, M, M, -M], 1.7976931348622137e+308),
         tuple([M, M, -1e307], 1.6976931348623159e+308),
-        tuple([1e16, 1., 1e-16], 10000000000000002.0),
+        tuple([1e16, 1., 1e-16], 10_000_000_000_000_002.0),
     ];
     foreach (i, test; tests)
     {
@@ -2205,7 +2207,9 @@ private template SummationType(F)
     version(X86) //workaround for Issue 13474
     {
         static if (!is(Unqual!F == real) && (isComplex!F || !is(Unqual!(typeof(F.init.re)) == real)))
-            pragma(msg, "Note: Summation algorithms on x86 use 80bit representation for single and double floating point numbers.");
+            enum note =  "Note: Summation algorithms on x86 use 80bit representation"
+                       ~ "for single and double floating point numbers.";
+            pragma(msg, note);
         static if (isComplex!F)
         {
             import std.complex : Complex;


### PR DESCRIPTION
I think we should try putting the linting off to a real bot.
This PR adds a execution of [dscanner](https://github.com/Hackerpilot/Dscanner).

We probably want to play with this for a while, maybe disable some checks or fix the codebase until we set the `--enforce` flag, which will exit the CI with an error.
Currently it outputs many messages, see e.g. [here](https://travis-ci.org/wilzbach/mir/jobs/122970079)

Other
- It is only run on travis subbuild - hence the version check (I reused it for the s3 check)
- As there is no binary release of dscanner, I created `releases.dlang.io` (a s3 bucket to which I will upload such release) - this speeds up the build! Otherwise there is still dub fetch & dub run.
