### PR TITLE
fix #98 - use -m64 for 64 bit windows

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -22,7 +22,8 @@ install:
   - dub --version
 
 build_script:
- - echo build
+ - echo dummy build script - dont remove me
 
 test_script:
- - dub test -b unittest-cov
+ - if "%APPVEYOR_JOB_ARCH%"=="x64" ( dub test -b test --arch=x86_64 )
+ - if "%APPVEYOR_JOB_ARCH%"=="x86" ( dub test -b test )


### PR DESCRIPTION
This should in theory fix #98 - I need to wait a couple of minutes until AppVeyor builds, so will let it open ;-)
