### PR TITLE
test 32bit on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,14 +10,22 @@ d:
  - dmd-2.068.2
  - ldc-1.0.0-alpha1
  - ldc-0.17.0
-install:
- - if [[ $(dmd --help | head -n 1 | cut -d ' ' -f 4) == 'v2.071.0' && $TRAVIS_OS_NAME == 'linux' ]] ; then export IS_LATEST_PHOBOS=1 ; fi
- - wget -O doveralls "https://github.com/ColdenCullen/doveralls/releases/download/v1.2.0/doveralls_linux_travis"
- - chmod +x doveralls
- - wget -O dscanner "http://releases.dlang.io/dscanner/0.3.0-git/dscanner"
- - chmod +x dscanner
+env:
+ - ARCH="x86_64"
+matrix:
+  include:
+    - {os: linux, d: dmd-2.071.0, env: ARCH="x86", addons: {apt: {packages: [[gcc-multilib]]}}}
+    - {os: linux, d: dmd-2.070.2, env: ARCH="x86", addons: {apt: {packages: [[gcc-multilib]]}}}
+    - {os: linux, d: dmd-2.069.2, env: ARCH="x86", addons: {apt: {packages: [[gcc-multilib]]}}}
+    - {os: linux, d: dmd-2.068.2, env: ARCH="x86", addons: {apt: {packages: [[gcc-multilib]]}}}
+    - {os: linux, d: ldc-1.0.0-alpha1, env: ARCH="x86", addons: {apt: {packages: [[gcc-multilib]]}}}
+    - {os: linux, d: ldc-0.17.0, env: ARCH="x86", addons: {apt: {packages: [[gcc-multilib]]}}}
+branches:
+  only:
+    - master
+    - stable
 script:
- - if [ "$IS_LATEST_PHOBOS" ] ; then ./dscanner --config .dscanner.ini --styleCheck source 2> /dev/null ; else echo "NOT_LATEST"; fi
- - dub test -b unittest-cov
+ - echo "$ARCH"
+ - dub test --arch "$ARCH" -b unittest-cov
 after_success:
  - bash <(curl -s https://codecov.io/bash)


### PR DESCRIPTION
Apparently it is as easy as adding `--arch x86`.

Please note that the [build matrix](https://docs.travis-ci.com/user/customizing-the-build/#Build-Matrix) now expands quite heavily, see [here](https://travis-ci.org/wilzbach/mir/builds/123489045)

Imho that's ok, because we have circleci as a fast check.

Also mir.las.sum seems to fail, see https://travis-ci.org/wilzbach/mir/jobs/123489047

(related to #105)
