### PR TITLE
fix builds on appveyor 64bit

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -21,7 +21,8 @@ environment:
     arch: x64
 
 matrix:
-  fast_finish: true
+  allow_failures:
+    - DC: ldc
 
 skip_tags: true
 branches:
@@ -96,7 +97,7 @@ build_script:
 
 test_script:
  - echo %PLATFORM%
- - echo %Darch
+ - echo %Darch%
  - echo %DC%
  - echo %PATH%
  - '%DC% --version'

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,30 +1,103 @@
-platform:
-  - x86
-  - x64
+platform: x64
 environment:
-  matrix:
-    - DMD: 2.071.0
-    - DMD: 2.070.2
+ matrix:
+  - DC: dmd
+    DVersion: 2.071.0
+    arch: x64
+  - DC: dmd
+    DVersion: 2.071.0
+    arch: x86
+  - DC: dmd
+    DVersion: 2.070.0
+    arch: x64
+  - DC: dmd
+    DVersion: 2.070.0
+    arch: x86
+  - DC: ldc
+    DVersion: '1.0.0-alpha1'
+    arch: x64
+  - DC: ldc
+    DVersion: 0.17.0
+    arch: x64
+
+matrix:
+  fast_finish: true
 
 skip_tags: true
+branches:
+  only:
+    - master
+    - stable
 
 install:
-  - set COMPILER_URL=http://downloads.dlang.org/releases/2.x/%DMD%/dmd.%DMD%.windows.7z
-  - powershell -Command Invoke-WebRequest %COMPILER_URL% -OutFile dmd.7z
-  - 7z x dmd.7z > nul
+  - ps: function SetUpDCompiler
+        {
+            if($env:DC -eq "dmd"){
+              if($env:arch -eq "x86"){
+                $env:DConf = "m32";
+              }
+              elseif($env:arch -eq "x64"){
+                $env:DConf = "m64";
+              }
+              echo "downloading ...";
+              $env:toolchain = "msvc";
+              $version = $env:DVersion;
+              Invoke-WebRequest "http://downloads.dlang.org/releases/2.x/$($version)/dmd.$($version).windows.7z" -OutFile "c:\dmd.7z";
+              echo "finished.";
+              pushd c:\\;
+              7z x dmd.7z > $null;
+              popd;
+            }
+            elseif($env:DC -eq "ldc"){
+              echo "downloading ...";
+              if($env:arch -eq "x86"){
+                $env:DConf = "m32";
+              }
+              elseif($env:arch -eq "x64"){
+                $env:DConf = "m64";
+              }
+              $env:toolchain = "msvc";
+              $version = $env:DVersion;
+              Invoke-WebRequest "https://github.com/ldc-developers/ldc/releases/download/v$($version)/ldc2-$($version)-win64-msvc.zip" -OutFile "c:\ldc.zip";
+              echo "finished.";
+              pushd c:\\;
+              7z x ldc.zip > $null;
+              popd;
+            }
+        }
+  - ps: SetUpDCompiler
   - powershell -Command Invoke-WebRequest https://code.dlang.org/files/dub-0.9.24-windows-x86.zip -OutFile dub.zip
   - 7z x dub.zip -odub > nul
-  - set binpath=dmd2/windows/bin
-  - set libpath=dmd2/windows/lib
   - set PATH=%CD%\%binpath%;%CD%\dub;%PATH%
-  - set LD_LIBRARY_PATH=%CD%\%libpath%;%LD_LIBRARY_PATH%
-  - dmd --version
   - dub --version
+
+before_build:
+  - ps: if($env:arch -eq "x86"){
+            $env:compilersetupargs = "x86";
+            $env:Darch = "x86";
+          }
+        elseif($env:arch -eq "x64"){
+            $env:compilersetupargs = "amd64";
+            $env:Darch = "x86_64";
+        }
+  - ps : if($env:DC -eq "dmd"){
+           $env:PATH += ";C:\dmd2\windows\bin;";
+         }
+         elseif($env:DC -eq "ldc"){
+           $version = $env:DVersion;
+           $env:PATH += ";C:\ldc2-$($version)-win64-msvc\bin";
+           $env:DC = "ldc2";
+         }
+  - ps: $env:compilersetup = "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall";
+  - '"%compilersetup%" %compilersetupargs%'
 
 build_script:
  - echo dummy build script - dont remove me
 
 test_script:
  - echo %PLATFORM%
- - if "%PLATFORM%"=="x64" ( dub test --arch=x86_64 )
- - if "%PLATFORM%"=="x86" ( dub test )
+ - echo %Darch
+ - echo %DC%
+ - echo %PATH%
+ - '%DC% --version'
+ - dub test --arch=%Darch% --compiler=%DC%


### PR DESCRIPTION
> Can't run '\bin\link.exe', check PATH

I think that setting the [LINKCMD64](http://stackoverflow.com/questions/21651357/64-bit-executables-with-dmd) is all that is needed, but AppVeyor takes quite a bit to run, so I leave this open here until verified.

Will ping you then ;-)
