### PR TITLE
circleci s3 deployment

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -12,7 +12,14 @@ dependencies:
     - dub --version
     - wget -O dscanner "http://releases.dlang.io/dscanner/0.3.0-git/dscanner"
     - chmod +x dscanner
+    - git submodule update --recursive --init
 test:
   override:
     - ./dscanner --config .dscanner.ini --styleCheck source 2> /dev/null
     - dub test
+    - rdmd bootDoc/generate.d --output=docs source
+deployment:
+  aws:
+    branch: master
+    commands:
+      - AWS_DEFAULT_REGION=eu-west-1 aws s3 sync --acl public-read --delete docs s3://docs.mir.dlang.io/latest


### PR DESCRIPTION
this fixes our s3 setup again - I already set the AWS credentials [here](https://circleci.com/gh/DlangScience/mir/edit#aws) so we should be ready to go!

My test [worked](http://docs.mir.dlang.io/latest/mir.las.sum.html).

PS: It doesn't add the index html for the documentation, do you want to add a `index.html` to our setup?
