### PR TITLE
add ddoc main page to bootdoc setup

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -17,7 +17,7 @@ test:
   override:
     - ./dscanner --config .dscanner.ini --styleCheck source 2> /dev/null
     - dub test
-    - rdmd bootDoc/generate.d --output=docs source
+    - rdmd bootDoc/generate.d --output=docs source --extra index.d
 deployment:
   aws:
     branch: master

--- a/index.d
+++ b/index.d
@@ -1,0 +1,23 @@
+/**
+Numeric library and mirror for upcoming numeric packages for the Dlang standard library.
+
+$(DL
+	$(DT $(DPMODULE ndslice)
+		$(DD Multidimensional Random Access Ranges and Arrays)
+	)
+	$(DT $(DPMODULE2 las, sum)
+		$(DD Functions and Output Ranges for Summation Algorithms. Works with user-defined types.)
+		$(DD Precise algorithm: improved analog of Python's `fsum`)
+        $(DD Pairwise algorithm: fast version for Input Ranges)
+        $(DD Kahan, KBN, and KB2 algorithms)
+	)
+	$(DT $(DPMODULE combinatorics)
+		$(DD $(DPMODULE2 combinatorics, permutations))
+		$(DD $(DPMODULE2 combinatorics, cartesianPower))
+		$(DD $(DPMODULE2 combinatorics, combinations))
+		$(DD $(DPMODULE2 combinatorics, combinationsRepeat))
+	)
+)
+
+*/
+module mir;

--- a/settings.ddoc
+++ b/settings.ddoc
@@ -1,5 +1,5 @@
 PROJECTNAME = Mir
-REFERENCETOP = mir.html
+REFERENCETOP = index.html
 REPOSRCTREE = https://github.com/DlangScience/mir/tree/master/source
 TITLEBARTEXT = <a href="https://github.com/DlangScience/mir">GitHub Page</a>
 RESOURCEROOT = ../bootDoc/


### PR DESCRIPTION
an initial overview page - probably needs more love.

@9il - can you fork please fork the `bootDoc` repo, so that I can start making changes to it. Thanks!
