### PR TITLE
enable enforce option for codestyle

### DIFF
--- a/.dscanner.ini
+++ b/.dscanner.ini
@@ -15,7 +15,7 @@ float_operator_check="true"
 number_style_check="true"
 ; Checks that opEquals, opCmp, toHash, and toString are either const, immutable
 ; , or inout.
-object_const_check="true"
+object_const_check="false"
 ; Checks for .. expressions where the left side is larger than the right.
 backwards_range_check="true"
 ; Checks for if statements whose 'then' block is the same as the 'else' block
@@ -29,9 +29,9 @@ unused_label_check="true"
 ; Checks for duplicate attributes
 duplicate_attribute="true"
 ; Checks that opEquals and toHash are both defined or neither are defined
-opequals_tohash_check="true"
+opequals_tohash_check="false"
 ; Checks for subtraction from .length properties
-length_subtraction_check="true"
+length_subtraction_check="false"
 ; Checks for methods or properties whose names conflict with built-in propertie
 ; s
 builtin_property_names_check="true"
@@ -42,9 +42,9 @@ logical_precedence_check="false"
 ; Checks for undocumented public declarations
 undocumented_declaration_check="true"
 ; Checks for poor placement of function attributes
-function_attribute_check="true"
+function_attribute_check="false"
 ; Checks for use of the comma operator
-comma_expression_check="true"
+comma_expression_check="false"
 ; Checks for local imports that are too broad
 local_import_check="false"
 ; Checks for variables that could be declared immutable

--- a/circle.yml
+++ b/circle.yml
@@ -15,7 +15,7 @@ dependencies:
     - git submodule update --recursive --init
 test:
   override:
-    - ./dscanner --config .dscanner.ini --styleCheck source 2> /dev/null
+    - ./dscanner --config .dscanner.ini --styleCheck $(find source/mir/* -type d | grep -v ndslice | tr '\n' ' ') 
     - dub test
     - rdmd bootDoc/generate.d --output=docs source --extra index.d
 deployment:


### PR DESCRIPTION
after #131, we can "enforce" the code style.
As tonight you already commited a couple of violations (e.g. too long lines) and I did too, we should really have an annoying bot that reminds us.
