### PR TITLE
Enable enforce codestyle

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -10,12 +10,12 @@ dependencies:
     - curl -fsSL --retry 3 http://code.dlang.org/files/dub-${DUB}-linux-x86_64.tar.gz | tar -C ~/dmd2/linux/bin64 -zxf -
     - dmd --version
     - dub --version
-    - wget -O dscanner "http://releases.dlang.io/dscanner/0.3.0-git/dscanner"
+    - wget -q -O dscanner "http://releases.dlang.io/dscanner/0.3.0-git/dscanner"
     - chmod +x dscanner
     - git submodule update --recursive --init
 test:
   override:
-    - ./dscanner --config .dscanner.ini --styleCheck $(find source/mir/* -type d | grep -v ndslice | tr '\n' ' ') 
+    - dscanResult=$(./dscanner --config .dscanner.ini --styleCheck $(find source/mir/* -type d | grep -v ndslice | tr '\n' ' ') 2> /dev/null ) ; if [ -z "${dscanResult}" ] ; then echo "No warnings found" ; else echo $dscanResult && $(exit 1); fi
     - dub test
     - rdmd bootDoc/generate.d --output=docs source --separator=_ --extra index.d
 deployment:


### PR DESCRIPTION
Last time you merged to quickly - I was still experimenting with the settings. It turns out that there's a bug in Dscanner that always yields an exit code of 1.
I know this expression is a bit ugly now, but it works ...
