### PR TITLE
update bootdoc folder on s3 deploy

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -26,3 +26,4 @@ deployment:
     branch: master
     commands:
       - AWS_DEFAULT_REGION=eu-west-1 aws s3 sync --acl public-read --delete docs s3://docs.mir.dlang.io/latest
+      - AWS_DEFAULT_REGION=eu-west-1 aws s3 sync --acl public-read --delete bootDoc s3://docs.mir.dlang.io/bootDoc


### PR DESCRIPTION
Turns out that the change didn't land because we need to update the bootDoc copy too.
