### PR TITLE
mir.ndslice: improve codestyle

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -18,7 +18,7 @@ dependencies:
     - chmod +x dscanner
 test:
   override:
-    - dscanResult=$(./dscanner --config .dscanner.ini --styleCheck $(find source/mir/* -type d | grep -v ndslice | tr '\n' ' ') 2> /dev/null ) ; if [ -z "${dscanResult}" ] ; then echo "No warnings found" ; else echo $dscanResult && $(exit 1); fi
+    - dscanResult=$(./dscanner --config .dscanner.ini --styleCheck source 2> /dev/null ) ; if [ -z "${dscanResult}" ] ; then echo "No warnings found" ; else echo $dscanResult && $(exit 1); fi
     - dub test
     - rdmd bootDoc/generate.d --output=docs source --separator=_ --extra index.d
 deployment:

--- a/source/mir/ndslice/iteration.d
+++ b/source/mir/ndslice/iteration.d
@@ -250,7 +250,8 @@ template rotated(size_t dimensionA, size_t dimensionB)
 }
 
 /// ditto
-Slice!(N, Range) rotated(size_t N, Range)(Slice!(N, Range) slice, size_t dimensionA, size_t dimensionB, sizediff_t k = 1)
+Slice!(N, Range) rotated(size_t N, Range)(Slice!(N, Range) slice,
+                         size_t dimensionA, size_t dimensionB, sizediff_t k = 1)
 in{
     {
         alias dimension = dimensionA;

--- a/source/mir/ndslice/package.d
+++ b/source/mir/ndslice/package.d
@@ -507,8 +507,8 @@ pure nothrow unittest
     assert(t1[4] == 200);
 
     t1[] *= t1[];
-    assert(t1[3] == 40000);
-    assert(t1[4] == 40000);
+    assert(t1[3] == 40_000);
+    assert(t1[4] == 40_000);
 
 
     assert(&t1[$ - 1] is &(t1.back()));

--- a/source/mir/ndslice/selection.d
+++ b/source/mir/ndslice/selection.d
@@ -910,7 +910,7 @@ auto byElement(size_t N, Range)(auto ref Slice!(N, Range) slice)
             size_t[N] _indexes;
 
             static if (canSave!PureRange)
-            auto save() @property
+            auto save()
             {
                 return typeof(this)(_slice.save, _length, _indexes);
             }
@@ -1145,7 +1145,7 @@ auto byElement(size_t N, Range)(auto ref Slice!(N, Range) slice)
                 return typeof(return)(i, j);
             }
 
-            size_t[N] index() @property
+            size_t[N] index() @property const
             {
                 pragma(inline, true);
                 return _indexes;
@@ -1403,7 +1403,7 @@ auto byElementInStandardSimplex(size_t N, Range)(auto ref Slice!(N, Range) slice
             size_t[N] _indexes;
 
             static if (canSave!PureRange)
-            auto save() @property
+            auto save()
             {
                 return typeof(this)(_slice.save, _length, maxCobeLength, sum, _indexes);
             }
@@ -1465,7 +1465,7 @@ auto byElementInStandardSimplex(size_t N, Range)(auto ref Slice!(N, Range) slice
                 }
             }
 
-            size_t[N] index() @property
+            size_t[N] index() @property const
             {
                 pragma(inline, true);
                 return _indexes;
@@ -1711,11 +1711,15 @@ template IotaSlice(size_t N)
     alias IotaSlice = Slice!(N, IotaMap!());
 }
 
-// undocumented
-// zero cost variant of `std.range.iota`
+/++
+Zero cost variant of `$(REF_ALTTEXT std.range.iota, iota, std, range)` for iotaSlice.
+See_also: $(LREF iotaSlice)
++/
 struct IotaMap()
 {
+    ///
     enum bool empty = false;
+    ///
     enum IotaMap save = IotaMap.init;
 
     static size_t opIndex()(size_t index) @safe pure nothrow @nogc @property

--- a/source/mir/ndslice/slice.d
+++ b/source/mir/ndslice/slice.d
@@ -414,7 +414,10 @@ private template _Range_Values(Names...)
 private template _Range_DeclarationList(Names...)
 {
     static if (Names.length)
-        enum string _Range_DeclarationList = "Range_" ~ Names[0] ~ " range_" ~ Names[0] ~ ", " ~ _Range_DeclarationList!(Names[1..$]);
+    {
+        enum string _Range_DeclarationList = "Range_" ~ Names[0] ~ " range_"
+             ~ Names[0] ~ ", " ~ _Range_DeclarationList!(Names[1..$]);
+    }
     else
         enum string _Range_DeclarationList = "";
 }
@@ -422,7 +425,10 @@ private template _Range_DeclarationList(Names...)
 private template _Slice_DeclarationList(Names...)
 {
     static if (Names.length)
-        enum string _Slice_DeclarationList = "Slice!(N, Range_" ~ Names[0] ~ ") slice_" ~ Names[0] ~ ", " ~ _Slice_DeclarationList!(Names[1..$]);
+    {
+        enum string _Slice_DeclarationList = "Slice!(N, Range_" ~ Names[0] ~ ") slice_"
+             ~ Names[0] ~ ", " ~ _Slice_DeclarationList!(Names[1..$]);
+    }
     else
         enum string _Slice_DeclarationList = "";
 }
@@ -1455,7 +1461,8 @@ struct Slice(size_t _N, _Range)
         if (dimension < N)
     {
         pragma(inline, true);
-        assert(n <= _lengths[dimension], __FUNCTION__ ~ ": n should be less than or equal to length!" ~ dimension.stringof);
+        assert(n <= _lengths[dimension],
+            __FUNCTION__ ~ ": n should be less than or equal to length!" ~ dimension.stringof);
         _lengths[dimension] -= n;
         _ptr += _strides[dimension] * n;
     }
@@ -1465,7 +1472,8 @@ struct Slice(size_t _N, _Range)
         if (dimension < N)
     {
         pragma(inline, true);
-        assert(n <= _lengths[dimension], __FUNCTION__ ~ ": n should be less than or equal to length!" ~ dimension.stringof);
+        assert(n <= _lengths[dimension],
+            __FUNCTION__ ~ ": n should be less than or equal to length!" ~ dimension.stringof);
         _lengths[dimension] -= n;
     }
 
@@ -1648,14 +1656,16 @@ struct Slice(size_t _N, _Range)
         assert(a != [[9, 2], [3, 4]]);
     }
 
+    ///
     _Slice opSlice(size_t dimension)(size_t i, size_t j)
         if (dimension < N)
     in   {
         assert(i <= j,
             "Slice.opSlice!" ~ dimension.stringof ~ ": the left bound must be less than or equal to the right bound.");
+        enum errorMsg = ": difference between the right and the left bounds"
+                        ~ " must be less than or equal to the length of the given dimension.";
         assert(j - i <= _lengths[dimension],
-            "Slice.opSlice!" ~ dimension.stringof ~
-            ": difference between the right and the left bounds must be less than or equal to the length of the given dimension.");
+              "Slice.opSlice!" ~ dimension.stringof ~ errorMsg);
     }
     body
     {
@@ -1802,7 +1812,8 @@ struct Slice(size_t _N, _Range)
                 && RN <= ReturnType!(opIndex!Slices).N)
         {
             auto slice = this[slices];
-            assert(slice._lengths[$ - RN .. $] == value._lengths, __FUNCTION__ ~ ": argument must have the corresponding shape.");
+            assert(slice._lengths[$ - RN .. $] == value._lengths,
+                __FUNCTION__ ~ ": argument must have the corresponding shape.");
             version(none) //future optimization
             static if ((isPointer!Range || isDynamicArray!Range) && (isPointer!RRange || isDynamicArray!RRange))
             {
@@ -2907,12 +2918,14 @@ private enum bool isType(T) = true;
 
 private enum isStringValue(alias T) = is(typeof(T) : string);
 
-private void _indexAssign(bool lastStrideEquals1, string op, size_t N, size_t RN, Range, RRange)(Slice!(N, Range) slice, Slice!(RN, RRange) value)
+private void _indexAssign(bool lastStrideEquals1, string op, size_t N, size_t RN, Range, RRange)
+                         (Slice!(N, Range) slice, Slice!(RN, RRange) value)
     if (N >= RN)
 {
     static if (N == 1)
     {
-        static if (lastStrideEquals1 && (isPointer!Range || isDynamicArray!Range) && (isPointer!RRange || isDynamicArray!RRange))
+        static if (lastStrideEquals1 && (isPointer!Range || isDynamicArray!Range)
+                   && (isPointer!RRange || isDynamicArray!RRange))
         {
             static if (isPointer!Range)
                 auto l = slice._ptr;


### PR DESCRIPTION
I still had these small improvement laying around - with them I can enable `dscanner` for `mir.ndslice` as it now passes our code style.

It's mostly just > 120 lines, missing `const`, better readability for numbers and undocumented methods.
