### PR TITLE
improve coverage for mir.las.sum

### DIFF
--- a/source/mir/las/sum.d
+++ b/source/mir/las/sum.d
@@ -1714,6 +1714,24 @@ public:
         }
     }
 
+    @nogc nothrow unittest
+    {
+        import std.typetuple;
+        import std.math: approxEqual;
+        with(Summation)
+        foreach (summation; TypeTuple!(naive, fast))
+        foreach (T; TypeTuple!(float, double, real))
+        {
+            Summator!(T, summation) sum = 1;
+            sum += 3.5;
+            assert(sum.sum.approxEqual(4.5));
+            sum = 2;
+            assert(sum.sum == 2);
+            sum -= 4;
+            assert(sum.sum.approxEqual(-2));
+        }
+    }
+
     static if (summation == Summation.precise)
     {
         ///Returns $(D true) if current sum is a NaN.


### PR DESCRIPTION
Just adds 

@9il - the remaining [uncovered bits](https://codecov.io/github/DlangScience/mir/source/mir/las/sum.d) here beyond my knowledge - do you mind to have a look?
- L76
- L757-759
- L763-765
- L1744, L1750, L1756 (I already tried to tackle this bit in #64 - but you reverted due to failure on Windows?)
