### PR TITLE
README: show the latest version in master shield to the user

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 [![codecov.io](https://codecov.io/github/DlangScience/mir/coverage.svg?branch=master)](https://codecov.io/github/DlangScience/mir?branch=master)
+[![Latest version](https://img.shields.io/github/tag/DlangScience/mir.svg?maxAge=3600)](http://code.dlang.org/packages/mir)
 [![License](https://img.shields.io/dub/l/mir.svg)](http://code.dlang.org/packages/mir)
 [![Gitter](https://img.shields.io/gitter/room/DlangScience/public.svg)](https://gitter.im/DlangScience/public)
 [![Circle CI](https://circleci.com/gh/DlangScience/mir.svg?style=svg)](https://circleci.com/gh/DlangScience/mir)
@@ -88,7 +89,6 @@ For example on  Linux this is `/usr/include/dlang/dmd/mir`
 
 Alternatively you can pass mir's directory directly to dmd and ldc using `-I <path-to-mir>`.
 
-
 ## Contributing
 
 See our [TODO List](https://github.com/DlangScience/mir/issues?q=is%3Aissue+is%3Aopen+label%3A%22New+Package%22).
@@ -96,4 +96,4 @@ Mir is very young and we are open for contributing to source code, documentation
 
 ## Notes
 
-- `mir.ndslice` is a development version of the `std.experimental.ndslice` package.
+- `mir.ndslice` is a development version of the [`std.experimental.ndslice`](http://dlang.org/phobos/std_experimental_ndslice.html) package.


### PR DESCRIPTION
There is also a [latest release](https://img.shields.io/github/release/dlangscience/mir.svg?maxAge=3600) shield, but I guess for now it's enough to just display the latest version in master.
