### PR TITLE
fix language: numeric -> numerical

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 Mir
 ======
-Generic Numeric Library for Science and Machine Learning.
+Generic Numerical Library for Science and Machine Learning.
 
 ## Contents
 

--- a/dub.json
+++ b/dub.json
@@ -1,6 +1,6 @@
 {
     "name": "mir",
-    "description": "Numeric library for Dlang",
+    "description": "Numerical library for Dlang",
     "copyright": "2015-2016, Ilya Yaroshenko, Mir Team",
     "authors": ["Ilya Yaroshenko"],
     "license": "BSL-1.0",

--- a/index.d
+++ b/index.d
@@ -1,5 +1,5 @@
 /**
-Numeric library and mirror for upcoming numeric packages for the Dlang standard library.
+Numerical library and mirror for upcoming numeric packages for the Dlang standard library.
 
 $(DL
 	$(DT $(LINK2 http://dlang.org/phobos-prerelease/std_experimental_ndslice.html, ndslice package)


### PR DESCRIPTION
As discussed on Gitter, "numerical" is apparently the better term.

see e.g. https://en.wikipedia.org/wiki/List_of_numerical_libraries
