### PR TITLE
test mir with ldc-1.0.0-beta1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ d:
  - dmd-2.070.2
  - dmd-2.069.2
  - dmd-2.068.2
- - ldc-1.0.0-alpha1
+ - ldc-1.0.0-beta1
  - ldc-0.17.0
 env:
  - ARCH="x86_64"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -14,7 +14,7 @@ environment:
     DVersion: 2.070.0
     arch: x86
   - DC: ldc
-    DVersion: '1.0.0-alpha1'
+    DVersion: '1.0.0-beta1'
     arch: x64
   - DC: ldc
     DVersion: 0.17.0


### PR DESCRIPTION
let's test whether ldc-1.0.0-beta1 works for us ;-)
(-> please wait until all CIs pass)

It's based on 2.070.2, so maybe we soon don't need all the `version` code for the allocator anymore ;-)

http://forum.dlang.org/thread/vnuknfqnlzzlxhzyfakc@forum.dlang.org
