### PR TITLE
update ldc to 1.0.0-beta2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ d:
  - dmd-2.070.2
  - dmd-2.069.2
  - dmd-2.068.2
- - ldc-1.0.0-alpha1
+ - ldc-1.0.0-beta2
  - ldc-0.17.0
 env:
  - ARCH="x86_64"


### PR DESCRIPTION
Seems like the ldc devs fixed the static linking error :)
https://github.com/ldc-developers/ldc/releases

@9il A bit of patience for travis this time please ;-)
