### PR TITLE
Fix a typo in GEMM formula

### DIFF
--- a/source/mir/blas/gemm.d
+++ b/source/mir/blas/gemm.d
@@ -18,7 +18,7 @@ Params:
     beta = scalar
     c = matrix
 Returns:
-    `c = alpha * a × x + beta * c`
+    `c = alpha * a × b + beta * c`
 Note:
     `gemm` implementation is naive for now.
 +/


### PR DESCRIPTION
`x` was copy-pasted from `gemv`
