### PR TITLE
update ldc to 1.0.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ d:
  - dmd-2.070.2
  - dmd-2.069.2
  - dmd-2.068.2
- - ldc-1.0.0-beta2
+ - ldc-1.0.0
  - ldc-0.17.0
 env:
  - ARCH="x86_64"
@@ -18,7 +18,7 @@ matrix:
     - {os: linux, d: dmd-2.070.2, env: ARCH="x86", addons: {apt: {packages: [[gcc-multilib]]}}}
     - {os: linux, d: dmd-2.069.2, env: ARCH="x86", addons: {apt: {packages: [[gcc-multilib]]}}}
     - {os: linux, d: dmd-2.068.2, env: ARCH="x86", addons: {apt: {packages: [[gcc-multilib]]}}}
-    - {os: linux, d: ldc-1.0.0-beta2, env: ARCH="x86", addons: {apt: {packages: [[gcc-multilib]]}}}
+    - {os: linux, d: ldc-1.0.0, env: ARCH="x86", addons: {apt: {packages: [[gcc-multilib]]}}}
     - {os: linux, d: ldc-0.17.0, env: ARCH="x86", addons: {apt: {packages: [[gcc-multilib]]}}}
 branches:
   only:


### PR DESCRIPTION
As by http://forum.dlang.org/post/lwsnqbravjqbnnryvjkx@forum.dlang.org, ldc-1.0.0 is now officially released :)
Let's test it!
