### PR TITLE
Add dub header to examples

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,7 +1,7 @@
 machine:
   environment:
     DMD: 2.071.0
-    DUB: 0.9.25
+    DUB: 1.0.0-beta.1
     PATH: "${HOME}/dmd2/linux/bin64:${PATH}"
     LD_LIBRARY_PATH: "${HOME}/dmd2/linux/lib64:${LD_LIBRARY_PATH}"
 checkout:
@@ -24,8 +24,11 @@ test:
     - rdmd ./checkwhitespace.d $(find source -name '*.d')
     - dub test
     - dub build -c median-filter
+    - dub build --single examples/median_filter.d
     - dub build -c means-of-columns
+    - dub build --single examples/means_of_columns.d
     - dub build -c lda-hoffman-sparse
+    - dub build --single examples/lda_hoffman_sparse.d
     - make -f doc/Makefile html
 deployment:
   aws:

--- a/examples/lda_hoffman_sparse.d
+++ b/examples/lda_hoffman_sparse.d
@@ -1,3 +1,9 @@
+#!/usr/bin/env dub
+/+ dub.sdl:
+name "lda_hoffman_sparse"
+dependency "mir" version=">0.15.1"
++/
+
 /++
 Butch LDA using online LDA
 +/

--- a/examples/means_of_columns.d
+++ b/examples/means_of_columns.d
@@ -1,3 +1,9 @@
+#!/usr/bin/env dub
+/+ dub.sdl:
+name "means_of_columns"
+dependency "mir" version=">0.15.1"
++/
+
 /**
 * This code uses std.experimental.ndslice to take the mean of the columns in
 * a 2d 100x1000 array and creates a benchmark of that code. Running on a 2015

--- a/examples/median_filter.d
+++ b/examples/median_filter.d
@@ -1,3 +1,10 @@
+#!/usr/bin/env dub
+/+ dub.sdl:
+name "median_filter"
+dependency "mir" version=">0.15.1"
+dependency "imageformats" version="~>6.0.0"
++/
+
 import mir.ndslice;
 
 /++


### PR DESCRIPTION
Adds the new dub header file to the examples and allows the examples to be directly executed like.
- At some point hopefully specifying a name will be optional
- Should we use `>0.15` instead? (See: https://github.com/dlang/dub/wiki/Version-management)
