### PR TITLE
Make Hoffman example runnable and add to CI

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -25,6 +25,7 @@ test:
     - dub test
     - dub build -c median-filter
     - dub build -c means-of-columns
+    - dub build -c lda-hoffman-sparse
     - make -f doc/Makefile html
 deployment:
   aws:

--- a/dub.json
+++ b/dub.json
@@ -33,6 +33,14 @@
             "targetType": "executable",
             "targetPath": "build",
             "sourceFiles": ["examples/means_of_columns.d"]
+        },
+        {
+            "name": "lda-hoffman-sparse",
+            "targetName": "lda-hoffman-sparse",
+            "targetType": "executable",
+            "targetPath": "build",
+            "sourceFiles": ["examples/lda_hoffman_sparse.d"]
         }
+
     ]
 }

--- a/examples/lda_hoffman_sparse.d
+++ b/examples/lda_hoffman_sparse.d
@@ -2,6 +2,7 @@
 Butch LDA using online LDA
 +/
 import std.file;
+import std.path;
 import std.string;
 import std.utf;
 import std.conv;
@@ -13,9 +14,15 @@ import mir.sparse;
 import mir.model.lda.hoffman;
 
 
-void main()
+void main(string[] args)
 {
-	auto stop = "data/stop_words"
+    string curFolder;
+    if (args.length > 1)
+        curFolder = args[1];
+    else
+        curFolder = thisExePath.dirName;
+
+	auto stop = curFolder.buildPath("data/stop_words")
 		.readText
 		.lineSplitter
 		.map!(toLower)
@@ -25,7 +32,7 @@ void main()
 	foreach(word; stop)
 		stopSet[word] = true;
 
-	auto dict = "data/words"
+	auto dict = curFolder.buildPath("data/words")
 		.readText
 		.lineSplitter
 		.map!(toLower)
@@ -37,7 +44,7 @@ void main()
 		.array
 		;
 
-	auto docs = "data/trndocs.dat"
+	auto docs = curFolder.buildPath("data/trndocs.dat")
 		.readText
 		.splitLines
 		;
@@ -57,7 +64,7 @@ void main()
 	auto comp = collection.compress;
 	auto k = 100;
 	import std.parallelism;
-	auto lda = LdaSparseHoffman!double(
+	auto lda = LdaHoffman!double(
 		k, // topics count
 		dict.length, // dictionary length
 		comp.length, // ~ value of documents


### PR DESCRIPTION
I just realized that currently the hoffman example doesn't compile, we probably should add it to the CI setup ;-)
While I was at it, I modified the file, s.t. it can take an input directory or alternative use the executable folder to find the data dir.
