### PR TITLE
mir.random.discrete - fix for zero probilities

### DIFF
--- a/source/mir/random/discrete.d
+++ b/source/mir/random/discrete.d
@@ -37,7 +37,7 @@ unittest
 
     // sample from the discrete distribution
     auto obs = new uint[cdPoints.length];
-    foreach (i; 0..1000)
+    foreach (i; 0..10_000)
         obs[ds()]++;
 }
 
@@ -81,10 +81,11 @@ struct Discrete(T)
         import std.range : assumeSorted;
 
         T v = uniform!("[)", T, T)(0, cdPoints[$-1], gen);
-        return cdPoints.assumeSorted!"a <= b".lowerBound(v).length;
+        return cdPoints.length - cdPoints.assumeSorted!"a < b".upperBound(v).length;
     }
 }
 
+// test with cumulative probs
 unittest
 {
     import std.random : Random;
@@ -95,10 +96,13 @@ unittest
     auto ds = discrete(cdPoints);
 
     auto obs = new uint[cdPoints.length];
-    foreach (i; 0..1000)
+    foreach (i; 0..10_000)
         obs[ds(gen)]++;
+
+    assert(obs == [1030, 1964, 1968, 4087, 951]);
 }
 
+// test with cumulative count
 unittest
 {
     import std.random : Random;
@@ -109,6 +113,25 @@ unittest
     auto ds = discrete(cdPoints);
 
     auto obs = new uint[cdPoints.length];
-    foreach (i; 0..1000)
+    foreach (i; 0..10_000)
         obs[ds(gen)]++;
+
+    assert(obs == [2536, 4963, 2501]);
+}
+
+// test with zero probabilities
+unittest
+{
+    import std.random : Random;
+    auto gen = Random(42);
+
+    // 0, 1, 2, 0, 1
+    auto cdPoints = [0, 1, 3, 3, 4];
+    auto ds = discrete(cdPoints);
+
+    auto obs = new uint[cdPoints.length];
+    foreach (i; 0..10_000)
+        obs[ds(gen)]++;
+
+    assert(obs == [0, 2536, 4963, 0, 2501]);
 }

--- a/source/mir/random/discrete.d
+++ b/source/mir/random/discrete.d
@@ -88,8 +88,8 @@ struct Discrete(T)
 // test with cumulative probs
 unittest
 {
-    import std.random : Random;
-    auto gen = Random(42);
+    import std.random : Mt19937;
+    auto gen = Mt19937(42);
 
     // 10%, 20%, 20%, 40%, 10%
     auto cdPoints = [0.1, 0.3, 0.5, 0.9, 1];
@@ -105,8 +105,8 @@ unittest
 // test with cumulative count
 unittest
 {
-    import std.random : Random;
-    auto gen = Random(42);
+    import std.random : Mt19937;
+    auto gen = Mt19937(42);
 
     // 1, 2, 1
     auto cdPoints = [1, 3, 4];
@@ -122,8 +122,8 @@ unittest
 // test with zero probabilities
 unittest
 {
-    import std.random : Random;
-    auto gen = Random(42);
+    import std.random : Mt19937;
+    auto gen = Mt19937(42);
 
     // 0, 1, 2, 0, 1
     auto cdPoints = [0, 1, 3, 3, 4];


### PR DESCRIPTION
(in reference to #235)

As @WebDrake pointed out `Discrete` doesn't handle zero probabilities well. 
Also as we don't use chi-squared tests, but I think it's at least helpful to insert the assert's for the currently tested distributions.

With zero probs we can't use `lowerBound`, because it will it will not stop on the first element, but go to all equal element. Hence we either count the first category twice or the third one.
Here's an example of what's going on:

``` d
import std.stdio;
import std.range;
auto cdPoints = [1, 3, 3, 4];
foreach (el; 0..5)
{
    writeln(el, "->", cdPoints.assumeSorted!"a < b".lowerBound(el));
}

foreach (el; 0..5)
    writeln(el, "->", cdPoints.assumeSorted!"a <= b".lowerBound(el));
```

```
0->[]
1->[] // would count first category twice
2->[1]
3->[1]
4->[1, 3, 3] // only for "[]"

0->[]
1->[1]
2->[1]
3->[1, 3, 3] // would count third category (the zero one)
4->[1, 3, 3, 4] //only for "[]"
```
