### PR TITLE
use local path for examples

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,8 +27,10 @@ branches:
 script:
  - echo "$ARCH"
  - dub test --arch "$ARCH" -b unittest-cov
- - dub build -c median-filter
- - dub build -c means-of-columns
+ - dub build --single examples/lda_hoffman_sparse.d
+ - dub fetch imageformats && dub build imageformats
+ - dub build --single examples/median_filter.d
+ - dub build --single examples/means_of_columns.d
 after_success:
  - bash <(curl -s https://codecov.io/bash)
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -14,7 +14,7 @@ environment:
     DVersion: 2.070.2
     arch: x86
   - DC: ldc
-    DVersion: '1.0.0'
+    DVersion: 1.0.0
     arch: x64
   - DC: ldc
     DVersion: 0.17.0
@@ -67,7 +67,7 @@ install:
             }
         }
   - ps: SetUpDCompiler
-  - powershell -Command Invoke-WebRequest https://code.dlang.org/files/dub-1.0.0-beta.1-windows-x86.zip -OutFile dub.zip
+  - powershell -Command Invoke-WebRequest https://code.dlang.org/files/dub-1.0.0-windows-x86.zip -OutFile dub.zip
   - 7z x dub.zip -odub > nul
   - set PATH=%CD%\%binpath%;%CD%\dub;%PATH%
   - dub --version
@@ -102,8 +102,11 @@ test_script:
  - echo %PATH%
  - '%DC% --version'
  - dub test --arch=%Darch% --compiler=%DC%
- - dub build -c median-filter
- - dub build -c means-of-columns
+ - dub build --single examples/lda_hoffman_sparse.d
+ - dub fetch imageformats
+ - dub build imageformats
+ - dub build --single examples/median_filter.d
+ - dub build --single examples/means_of_columns.d
 
 notifications:
  - provider: Webhook

--- a/circle.yml
+++ b/circle.yml
@@ -23,12 +23,10 @@ test:
     - grep -nE "(for|foreach|foreach_reverse|if|while)\(" $(find source -name '*.d'); test $? -eq 1
     - rdmd ./checkwhitespace.d $(find source -name '*.d')
     - dub test
-    - dub build -c median-filter
-    - dub build --single examples/median_filter.d
-    - dub build -c means-of-columns
-    - dub build --single examples/means_of_columns.d
-    - dub build -c lda-hoffman-sparse
     - dub build --single examples/lda_hoffman_sparse.d
+    - dub fetch imageformats && dub build imageformats
+    - dub build --single examples/median_filter.d
+    - dub build --single examples/means_of_columns.d
     - make -f doc/Makefile html
 deployment:
   aws:

--- a/dub.json
+++ b/dub.json
@@ -16,31 +16,6 @@
         {
             "name": "dynamic-lib",
             "targetType": "dynamicLibrary",
-        },
-        {
-            "name": "median-filter",
-            "targetName": "median-filter",
-            "targetType": "executable",
-            "targetPath": "build",
-            "sourceFiles": ["examples/median_filter.d"],
-            "dependencies": {
-                "imageformats": "~>6.0.0"
-            },
-        },
-        {
-            "name": "means-of-columns",
-            "targetName": "means-of-columns",
-            "targetType": "executable",
-            "targetPath": "build",
-            "sourceFiles": ["examples/means_of_columns.d"]
-        },
-        {
-            "name": "lda-hoffman-sparse",
-            "targetName": "lda-hoffman-sparse",
-            "targetType": "executable",
-            "targetPath": "build",
-            "sourceFiles": ["examples/lda_hoffman_sparse.d"]
         }
-
     ]
 }

--- a/examples/lda_hoffman_sparse.d
+++ b/examples/lda_hoffman_sparse.d
@@ -1,7 +1,7 @@
 #!/usr/bin/env dub
 /+ dub.sdl:
 name "lda_hoffman_sparse"
-dependency "mir" version=">0.15.1"
+dependency "mir" path=".."
 +/
 
 /++
@@ -26,7 +26,7 @@ void main(string[] args)
     if (args.length > 1)
         curFolder = args[1];
     else
-        curFolder = thisExePath.dirName;
+        curFolder = getcwd.buildPath("examples");
 
 	auto stop = curFolder.buildPath("data/stop_words")
 		.readText

--- a/examples/means_of_columns.d
+++ b/examples/means_of_columns.d
@@ -1,7 +1,7 @@
 #!/usr/bin/env dub
 /+ dub.sdl:
 name "means_of_columns"
-dependency "mir" version=">0.15.1"
+dependency "mir" path=".."
 +/
 
 /**
@@ -17,7 +17,7 @@ dependency "mir" version=">0.15.1"
 *     means = numpy.mean(data, axis=0)
 *
 * and we benchmark the numpy.mean line using the following Python command,
-* 
+*
 *    python -m timeit \
 *         -s 'import numpy; data = numpy.arange(100000).reshape((100, 1000))' \
 *         'means = numpy.mean(data, axis=0)'
@@ -25,7 +25,6 @@ dependency "mir" version=">0.15.1"
 * then we get a mean running time of 145 µs. That means the version D is 3.625x
 * faster than the numpy version.
 */
-
 
 import std.range : iota;
 import std.array : array;

--- a/examples/median_filter.d
+++ b/examples/median_filter.d
@@ -1,7 +1,7 @@
 #!/usr/bin/env dub
 /+ dub.sdl:
 name "median_filter"
-dependency "mir" version=">0.15.1"
+dependency "mir" path=".."
 dependency "imageformats" version="~>6.0.0"
 +/
 


### PR DESCRIPTION
@9il I discovered that `dub` supports the `path` option to supply local dependencies -> let's clean our `dub.json`
