### PR TITLE
clean dub.json from flex example and use single file syntax

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -102,6 +102,7 @@ test_script:
  - echo %PATH%
  - '%DC% --version'
  - dub test --arch=%Darch% --compiler=%DC%
+ - dub build --single examples/flex_plot.d
  - dub build -c median-filter
  - dub build -c means-of-columns
 

--- a/circle.yml
+++ b/circle.yml
@@ -23,6 +23,7 @@ test:
     - grep -E "(for|foreach|foreach_reverse|if|while)\(" $(find source -name '*.d'); test $? -eq 1
     - rdmd ./checkwhitespace.d $(find source -name '*.d')
     - dub test
+    - dub build --single examples/flex_plot.d
     - dub build -c median-filter
     - dub build --single examples/median_filter.d
     - dub build -c means-of-columns

--- a/dub.json
+++ b/dub.json
@@ -40,19 +40,6 @@
             "targetType": "executable",
             "targetPath": "build",
             "sourceFiles": ["examples/lda_hoffman_sparse.d"]
-        },
-        {
-            "name": "flex-plot",
-            "targetName": "flex-plot",
-            "targetType": "executable",
-            "dependencies": {
-                "pyd": "~>0.9.8",
-            },
-            "subConfigurations": {
-                "pyd": "python35",
-            },
-            "sourceFiles": ["examples/flex_plot.d"],
-            "versions": ["Flex_logging"],
         }
     ]
 }

--- a/examples/flex_plot.d
+++ b/examples/flex_plot.d
@@ -1,6 +1,11 @@
-/**
-Simple plot
-*/
+#!/usr/bin/env dub
+/+ dub.sdl:
+name "flex_plot"
+dependency "mir" path=".."
+dependency "pyd" version="~>0.9.8"
+versions "Flex_logging"
+subConfigurations "pyd" "python35"
++/
 import mir.random.flex: FlexInterval;
 import std.array : array;
 import std.stdio : writeln, writefln, File;


### PR DESCRIPTION
@9il our other examples also use SDLang and imho it's more readable for such a short list of examples.

See also #250 that does the cleanup for the other files

Plotting can be done with e.g. this command:

```
./examples/flex_plot.d -p=false -r=1.3 6
``
```
