### PR TITLE
fix travis for imageformats

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ script:
  - echo "$ARCH"
  - dub test --arch "$ARCH" -b unittest-cov
  - dub build --single examples/lda_hoffman_sparse.d
- - dub fetch imageformats && dub build imageformats
+ - dub fetch imageformats --version=6.0.0 && dub build imageformats
  - dub build --single examples/median_filter.d
  - dub build --single examples/means_of_columns.d
 after_success:


### PR DESCRIPTION
@9il I don't know what happened, but this doesn't look good:

![image](https://cloud.githubusercontent.com/assets/4370550/16924975/3fe3337a-4d22-11e6-9b9f-c08267f2a511.png)

Let's see whether this quick fix resolves the problem.
