### PR TITLE
mir.random.nonuniform: Add Ziggurat method for Normal & Exponential

### DIFF
--- a/examples/nonuniform_plot.d
+++ b/examples/nonuniform_plot.d
@@ -1,0 +1,99 @@
+#!/usr/bin/env dub
+/+ dub.sdl:
+name "nonuniform_plot"
+dependency "mir" path=".."
+dependency "pyd" version="~>0.9.8"
+subConfigurations "pyd" "python35"
++/
+import pyd.embedded : py_init;
+
+shared static this() {
+    py_init();
+}
+
+// plot histogram with matplotlib
+void histogram(S, Pdf)(S[] values, string fileName, string title, Pdf pdf)
+{
+    import pyd.embedded : InterpContext;
+    import pyd.extra : d_to_python_numpy_ndarray;
+
+    static immutable script = `
+        import matplotlib.pyplot as plt
+        import numpy as np
+        n, bins, patches = plt.hist(sample, num_bins, normed=1)
+        xmin, xmax = plt.xlim()
+        plt.plot(xs, ys, color='black')
+        plt.title(title)
+        plt.savefig(fileName, bbox_inches='tight')
+        plt.close()
+    `;
+
+    import std.algorithm.searching: minPos, maxPos;
+    import std.array :array;
+    import std.range : front, iota;
+    double[] xs = iota(values.minPos.front, values.maxPos.front, 0.1).array;
+    double[] ys = new double[xs.length];
+    foreach (i, x; xs)
+        ys[i] = pdf(x);
+
+    auto pythonContext = new InterpContext();
+    pythonContext.sample = values.d_to_python_numpy_ndarray;
+    pythonContext.num_bins = 100;
+    pythonContext.fileName = fileName;
+    pythonContext.title = title;
+    pythonContext.xs = xs.d_to_python_numpy_ndarray;
+    pythonContext.ys = ys.d_to_python_numpy_ndarray;
+    pythonContext.py_stmts(script);
+}
+
+
+void pnormal()
+{
+    import std.math: exp, PI, sqrt;
+    import std.random : Mt19937;
+    import mir.random.nonuniform;
+
+    auto n = 10_000;
+    auto fileName = "norm";
+    auto title = "NormalDist";
+    auto gen = Mt19937(42);
+    alias S = double;
+
+    auto z = normal!(S, uint)();
+    S[] values = new S[n];
+
+    foreach (ref v; values)
+        v = z(gen);
+
+    double s = sqrt(2 * PI);
+    auto pdf = (double x) => exp(double(-0.5) * x * x) / s;
+    values.histogram(fileName ~ "_hist.pdf", title, pdf);
+}
+
+void pexponential()
+{
+    import std.math: exp;
+    import std.random : Mt19937;
+    import mir.random.nonuniform;
+
+    auto n = 10_000;
+    auto fileName = "expo";
+    auto title = "ExponentialDist";
+    auto gen = Mt19937(42);
+    alias S = double;
+
+    auto z = exponential!(S, uint)();
+    S[] values = new S[n];
+
+    foreach (ref v; values)
+        v = z(gen);
+
+    auto pdf = (double x) => exp(-x);
+    values.histogram(fileName ~ "_hist.pdf", title, pdf);
+}
+
+void main()
+{
+    pnormal();
+    pexponential();
+}

--- a/source/mir/random/nonuniform.d
+++ b/source/mir/random/nonuniform.d
@@ -120,6 +120,13 @@ private:
     T blockArea;
 
 public:
+    /**
+    Params:
+        pdf = probability density function
+        invPdf = inverse probability density function
+        rightEnd = left point of the right-most block
+        blockArea =  area of every column
+    */
     this(T function(T x) pdf, T function(T x) invPdf, T rightEnd, T blockArea)
     {
         this.pdf = pdf;

--- a/source/mir/random/nonuniform.d
+++ b/source/mir/random/nonuniform.d
@@ -16,12 +16,12 @@ Setup a _normal distribution sampler.
 
 Params:
     T = floating-point type that should be sampled
-    R = unsigned UIntType of the random generator
+    UIntType = unsigned UIntType of the random generator
 
 Returns:
     A $(LREF Ziggurat) sampler that can be called to sample from the distribution.
 */
-auto normal(T, R = uint)()
+auto normal(T, UIntType = uint)()
 {
     import mir.internal.math : exp, log, sqrt;
 
@@ -50,7 +50,7 @@ auto normal(T, R = uint)()
         }
     };
 
-    return Ziggurat!(T, fallback, R, true)(pdf, invPdf, 128, rightEnd, T(9.91256303526217e-3));
+    return Ziggurat!(T, fallback, UIntType, true)(pdf, invPdf, 128, rightEnd, T(9.91256303526217e-3));
 }
 
 /**
@@ -63,7 +63,7 @@ Params:
 Returns:
     A $(LREF Ziggurat) sampler that can be called to sample from the distribution.
 */
-auto exponential(T, R = uint)()
+auto exponential(T, UIntType = uint)()
 {
     import mir.internal.math : exp, log;
 
@@ -80,7 +80,7 @@ auto exponential(T, R = uint)()
         }
     };
 
-    return Ziggurat!(T, fallback, R, false)(pdf, invPdf, 256, T(7.697117470131487), T(3.949659822581572e-3));
+    return Ziggurat!(T, fallback, UIntType, false)(pdf, invPdf, 256, T(7.697117470131487), T(3.949659822581572e-3));
 }
 
 /**
@@ -92,7 +92,7 @@ References:
     Marsaglia, George, and Wai Wan Tsang. "The ziggurat method for generating random variables."
     Journal of statistical software 5.8 (2000): 1-7.
 */
-struct Ziggurat(T, string _fallback, R = uint, bool bothSides)
+struct Ziggurat(T, string _fallback, UIntType, bool bothSides)
     if (isNumeric!T)
 {
 
@@ -132,7 +132,7 @@ public:
         this.blockArea = blockArea;
 
         // scale factor to the range of UIntType
-        T maxT = bothSides ? R.max / 2 : R.max;
+        T maxT = bothSides ? UIntType.max / 2 : UIntType.max;
         kMask = k - 1;
 
         auto xn = rightEnd; // Next x_{i+1}
@@ -177,7 +177,7 @@ public:
         import std.random : uniform;
         import std.traits : Signed;
         import std.range : ElementType;
-        import std.mir.internal : fabs;
+        import std.math : abs;
 
         // TODO: option for inlining
         for (;;)
@@ -196,7 +196,7 @@ public:
             // U * x_i < x_{i+1}
             static if (bothSides)
             {
-                if (fabs(u) < xDiv[i])
+                if (abs(u) < xDiv[i])
                     return u * xScaled[i];
             }
             else

--- a/source/mir/random/nonuniform.d
+++ b/source/mir/random/nonuniform.d
@@ -45,7 +45,7 @@ auto normal(T, UIntType = uint)()
                 u = uniform!("[]", T, T)(0, 1, gen);
                 y = -log(u);
             }
-            while(y + y < x * x);
+            while (y + y < x * x);
             return isPositive ? rightEnd + x : -rightEnd - x;
         }
     };

--- a/source/mir/random/nonuniform.d
+++ b/source/mir/random/nonuniform.d
@@ -1,0 +1,246 @@
+/**
+Non-uniform distributions.
+
+License: $(LINK2 http://boost.org/LICENSE_1_0.txt, Boost License 1.0).
+
+Authors: Sebastian Wilzbach
+*/
+
+module mir.random.nonuniform;
+
+import std.traits : isNumeric;
+import std.stdio;
+
+/**
+Setup a _normal distribution sampler.
+
+Params:
+    T = floating-point type that should be sampled
+    R = unsigned UIntType of the random generator
+
+Returns:
+    A $(LREF Ziggurat) sampler that can be called to sample from the distribution.
+*/
+auto normal(T, R = uint)()
+{
+    import mir.internal.math : exp, log, sqrt;
+
+    auto pdf    = (T x) => cast(T) exp(T(-0.5) * x * x);
+    auto invPdf = (T x) => cast(T) sqrt(T(-2) * log(x));
+
+    // values from [Marsaglia00]
+    T rightEnd = 3.442619855899;
+
+    /// generate x for the last block (aka tail-block)
+    enum fallback = q{
+        T fallback(RNG)(bool isPositive, ref RNG gen) const
+        {
+            import std.random : uniform;
+            import std.math : log;
+            T x, y, u;
+            do
+            {
+                u = uniform!("[]", T, T)(0, 1, gen);
+                x = -log(u) / fs[$ - 1];
+                u = uniform!("[]", T, T)(0, 1, gen);
+                y = -log(u);
+            }
+            while(y + y < x * x);
+            return isPositive ? rightEnd + x : -rightEnd - x;
+        }
+    };
+
+    return Ziggurat!(T, fallback, R, true)(pdf, invPdf, 128, rightEnd, T(9.91256303526217e-3));
+}
+
+/**
+Setup an _exponential distribution sampler.
+
+Params:
+    T = floating-point type that should be sampled
+    R = unsigned UIntType of the random generator
+
+Returns:
+    A $(LREF Ziggurat) sampler that can be called to sample from the distribution.
+*/
+auto exponential(T, R = uint)()
+{
+    import mir.internal.math : exp, log;
+
+    auto pdf    = (T x) => cast(T) exp(-x);
+    auto invPdf = (T x) => cast(T) -log(x);
+
+    // values from [Marsaglia00]
+    enum fallback = q{
+        T fallback(RNG)(ref RNG gen) const
+        {
+            import std.random : uniform;
+            auto u = uniform!("[]", T, T)(0, 1, gen);
+            return 7.69711 - u;
+        }
+    };
+
+    return Ziggurat!(T, fallback, R, false)(pdf, invPdf, 256, T(7.697117470131487), T(3.949659822581572e-3));
+}
+
+/**
+Ziggurat algorithm for generating a random variable from a montone, decreasing density.
+
+Complexity: O_avg: O(1)
+
+References:
+    Marsaglia, George, and Wai Wan Tsang. "The ziggurat method for generating random variables."
+    Journal of statistical software 5.8 (2000): 1-7.
+*/
+struct Ziggurat(T, string _fallback, R = uint, bool bothSides)
+    if (isNumeric!T)
+{
+
+private:
+
+    /// monotone decreasing probability density function
+    /// constants don't matter
+    T function(T x) pdf;
+    T function(T x) invPdf;
+
+    /// precalculate difference x_i / x_{i+1}
+    T[] xDiv;
+    /// precalculate scaling to R.max for x_i
+    T[] xScaled;
+    /// precalculate pdf value for x_i
+    T[] fs;
+
+    /// number of blocks
+    size_t k;
+    // mask to use to get the first log_2 k bits (=k - 1)
+    size_t kMask;
+
+    /// left-point of the right-most block
+    T rightEnd;
+
+    /// area of every column
+    T blockArea;
+
+public:
+    this(T function(T x) pdf, T function(T x) invPdf, size_t k, T rightEnd,
+         T blockArea)
+    {
+        this.pdf = pdf;
+        this.invPdf = invPdf;
+        this.k = k;
+        this.rightEnd = rightEnd;
+        this.blockArea = blockArea;
+
+        // scale factor to the range of UIntType
+        T maxT = bothSides ? R.max / 2 : R.max;
+        kMask = k - 1;
+
+        auto xn = rightEnd; // Next x_{i+1}
+        auto xc = xn; // Current x_i
+        auto fn = pdf(xn);
+
+        // k_i = floor(2^32 (x_{i-1} / x_i))
+        xDiv    = new T[k];
+        xDiv[0] = (xn * fn / blockArea) * maxT;
+        xDiv[1] = 0;
+
+        // w_i = 0.5^32 * x_i
+        xScaled        = new T[k];
+        xScaled[0]     = (blockArea / fn) / maxT;
+        xScaled[$ - 1] = xn / maxT;
+
+        // f_i = f(x_i)
+        fs        = new T[k];
+        fs[0]     = T(1);
+        fs[$ - 1] = fn;
+
+        for (auto i = k - 2; i >= 1; i--)
+        {
+            xn = invPdf(blockArea / xn + fn);
+            xDiv[i + 1] = (xn / xc) * maxT;
+            fn = fs[i] = pdf(xn);
+            xScaled[i] = xn / maxT;
+            xc = xn;
+        }
+    }
+
+    /// samples a value from the discrete distribution
+    T opCall() const
+    {
+        import std.random : rndGen;
+        return opCall(rndGen);
+    }
+
+    /// samples a value from the discrete distribution using a custom random generator
+    T opCall(RNG)(ref RNG gen) const
+    {
+        import std.random : uniform;
+        import std.traits : Signed;
+        import std.range : ElementType;
+        import std.mir.internal : fabs;
+
+        // TODO: option for inlining
+        for (;;)
+        {
+            static if (bothSides)
+                Signed!(ElementType!RNG) u = gen.front;
+            else
+                auto u = gen.front;
+
+            gen.popFront();
+
+            // TODO: this is a bit biased
+            size_t i = u & kMask;
+            //size_t i = uniform!("[)", size_t, size_t)(0, kMask, gen);
+
+            // U * x_i < x_{i+1}
+            static if (bothSides)
+            {
+                if (fabs(u) < xDiv[i])
+                    return u * xScaled[i];
+            }
+            else
+            {
+                if (u < xDiv[i])
+                    return u * xScaled[i];
+            }
+
+            if (i == 0)
+            {
+                // generate x from tail block
+                static if (bothSides)
+                    return fallback(u > 0, gen);
+                else
+                    return fallback(gen);
+            }
+            else
+            {
+                auto x = u * xScaled[i];
+                if (fs[i] + u * (fs[i - 1] - fs[i]) < pdf(x))
+                    return x;
+            }
+        }
+    }
+
+private:
+    mixin(_fallback);
+}
+
+unittest
+{
+    import std.random : Mt19937;
+    auto gen = Mt19937(42);
+
+    alias T = double;
+    auto z = normal!(T, uint)();
+    auto n = 10_000;
+    auto obs = new T[n];
+    foreach (i; 0..n)
+    {
+        obs[i] = z(gen);
+    }
+
+    import std.algorithm.iteration : sum;
+    import std.math : approxEqual;
+    assert((obs.sum / n).approxEqual(-0.02368));
+}


### PR DESCRIPTION
Adds the Ziggurat sampling algorithm for Normal & Exponential distribution.

1) [Paper](http://www.jstatsoft.org/v05/i08/paper)

>   Marsaglia, George, and Wai Wan Tsang. "The ziggurat method for generating random variables."
>     Journal of statistical software 5.8 (2000): 1-7.

2) Thoughts
-  [ ] there are two other important papers
  -  [design flaws of the Ziggurat algorithm](http://arxiv.org/pdf/math/0603058) - the main critic is that the same variable is used to pick the block & value
  -  [An Improved Ziggurat Method to Generate Normal Random Samples](http://www.doornik.com/research/ziggurat.pdf)
- [ ] it doesn't look perfect yet, the mean is `-0.02` :/
- [ ] Ziggurat works for all distributions that can be reduced to a all monotone decreasing distributions (-> will assemble a list tomorrow)

3) Distribution plots (`dub ./examples/nonuniform_plot.d`):

![image](https://cloud.githubusercontent.com/assets/4370550/16937738/ef225f7e-4d71-11e6-81f9-3212212f7333.png)

![image](https://cloud.githubusercontent.com/assets/4370550/16937623/df708098-4d70-11e6-9b80-6c8e17924810.png)

Ping @joseph-wakeling-sociomantic @9il
