### PR TITLE
Flex2 - first benchmark

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ __test__d_source_library__
 
 *.sublime-project
 flex_plot_test_*
+trace.*

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -117,7 +117,7 @@ test_script:
  - '%DC% --version'
  - dub test --arch=%Darch% --compiler=%DC%
  - dub build --single examples/lda_hoffman_sparse.d
- - dub fetch imageformats
+ - dub fetch imageformats --version 6.0.0
  - dub build imageformats
  - dub build --single examples/median_filter.d
  - dub build --single examples/means_of_columns.d

--- a/benchmarks/flex/normal_dist.d
+++ b/benchmarks/flex/normal_dist.d
@@ -22,13 +22,14 @@ LDC - the LLVM D compiler (798cda):
 
 $ dub run --build=release-nobounds --compiler=ldmd2-git --single benchmarks/flex/normal_dist.d
 
-boxMueller.naive   = 12 secs, 36 ms, and 998 μs
-boxMueller.hap     = 40 secs, 844 ms, 230 μs, and 6 hnsecs
-boxMueller.dstats  = 8 secs, 4 ms, 556 μs, and 4 hnsecs
-flexNormal.slow    = 14 secs, 54 ms, 592 μs, and 4 hnsecs
-flexNormal.medium  = 12 secs, 13 ms, 252 μs, and 9 hnsecs
-flexNormal.fast    = 11 secs, 174 ms, 573 μs, and 5 hnsecs
-ziggurat           = 3 secs, 538 ms, 75 μs, and 9 hnsecs
+boxMueller.naive   =   850 ms, stddev: 82  ms
+boxMueller.hap     =  3618 ms, stddev: 4   ms
+boxMueller.dstats  =   801 ms, stddev: 2   ms
+boxMueller.atmos   =   934 ms, stddev: 2   ms
+flexNormal.slow    =  1406 ms, stddev: 4   ms
+flexNormal.medium  =  1206 ms, stddev: 1   ms
+flexNormal.fast    =  1124 ms, stddev: 0   ms
+ziggurat           =   357 ms, stddev: 5   ms
 +/
 
 import mir.random.flex;
@@ -97,7 +98,8 @@ void main()
     auto flexNormalMedium = genNormal!S(1.1);
     auto flexNormalFast = genNormal!S(1.0001);
 
-    auto zigguratNormal = normal!(S, uint)();
+    // mir ziggurat is temporarily excluded as it hasn't been merged yet
+    //auto zigguratNormal = normal!(S, uint)();
 
     // just pick any rng gen, it will have the same speed for all algorithms
     import std.random : Mt19937;
@@ -131,7 +133,7 @@ void main()
             { r += flexNormalSlow(gen); },
             { r += flexNormalMedium(gen); },
             { r += flexNormalFast(gen); },
-            { r += zigguratNormal(gen); },
+            //{ r += zigguratNormal(gen); },
         )(nrSamples);
 
         // log run times
@@ -154,198 +156,4 @@ void main()
         writef(", stddev: %-3d ms", report.stdev.to!long.hnsecs.total!"msecs");
         writeln();
     }
-}
-
-
-// the ziggurat implementation is WIP, as dub doesn't support pure git modules yet,
-// it was just copied over here
-
-
-
-
-import std.traits : isNumeric;
-
-/**
-Setup a _normal distribution sampler.
-
-Params:
-    T = floating-point type that should be sampled
-    UIntType = unsigned UIntType of the random generator
-
-Returns:
-    A $(LREF Ziggurat) sampler that can be called to sample from the distribution.
-*/
-auto normal(T, UIntType = uint)()
-{
-    import mir.internal.math : exp, log, sqrt;
-
-    auto pdf    = (T x) => cast(T) exp(T(-0.5) * x * x);
-    auto invPdf = (T x) => cast(T) sqrt(T(-2) * log(x));
-
-    // values from [Marsaglia00]
-    T rightEnd = 3.442619855899;
-
-    /// generate x for the last block (aka tail-block)
-    enum fallback = q{
-        T fallback(RNG)(bool isPositive, ref RNG gen) const
-        {
-            import std.random : uniform;
-            import std.math : log;
-            T x, y, u;
-            do
-            {
-                u = uniform!("[]", T, T)(0, 1, gen);
-                x = -log(u) / fs[$ - 1];
-                u = uniform!("[]", T, T)(0, 1, gen);
-                y = -log(u);
-            }
-            while (y + y < x * x);
-            return isPositive ? rightEnd + x : -rightEnd - x;
-        }
-    };
-
-    return Ziggurat!(T, fallback, UIntType, 128, true)(pdf, invPdf, rightEnd, T(9.91256303526217e-3));
-}
-
-/**
-Ziggurat algorithm for generating a random variable from a montone, decreasing density.
-
-Complexity: O_avg: O(1)
-
-References:
-    Marsaglia, George, and Wai Wan Tsang. "The ziggurat method for generating random variables."
-    Journal of statistical software 5.8 (2000): 1-7.
-*/
-struct Ziggurat(T, string _fallback, UIntType, size_t numberOfBlocks, bool bothSides)
-    if (isNumeric!T)
-{
-
-private:
-
-    /// monotone decreasing probability density function
-    /// constants don't matter
-    T function(T x) pdf;
-    T function(T x) invPdf;
-
-    /// precalculate difference x_i / x_{i+1}
-    T[numberOfBlocks] xDiv;
-    /// precalculate scaling to R.max for x_i
-    T[numberOfBlocks] xScaled;
-    /// precalculate pdf value for x_i
-    T[numberOfBlocks] fs;
-
-    // mask to use to get the first log_2 k bits (=k - 1)
-    enum size_t kMask = numberOfBlocks - 1;
-
-    /// left-point of the right-most block
-    T rightEnd;
-
-    /// area of every column
-    T blockArea;
-
-public:
-    /**
-    Params:
-        pdf = probability density function
-        invPdf = inverse probability density function
-        rightEnd = left point of the right-most block
-        blockArea =  area of every column
-    */
-    this(T function(T x) pdf, T function(T x) invPdf, T rightEnd, T blockArea)
-    {
-        this.pdf = pdf;
-        this.invPdf = invPdf;
-        this.rightEnd = rightEnd;
-        this.blockArea = blockArea;
-
-        // scale factor to the range of UIntType
-        T maxT = bothSides ? UIntType.max / 2 : UIntType.max;
-
-        auto xn = rightEnd; // Next x_{i+1}
-        auto xc = xn; // Current x_i
-        auto fn = pdf(xn);
-
-        // k_i = floor(2^32 (x_{i-1} / x_i))
-        xDiv[0] = (xn * fn / blockArea) * maxT;
-        xDiv[1] = 0;
-
-        // w_i = 0.5^32 * x_i
-        xScaled[0]     = (blockArea / fn) / maxT;
-        xScaled[$ - 1] = xn / maxT;
-
-        // f_i = f(x_i)
-        fs[0]     = T(1);
-        fs[$ - 1] = fn;
-
-        for (auto i = xScaled.length - 2; i >= 1; i--)
-        {
-            xn = invPdf(blockArea / xn + fn);
-            xDiv[i + 1] = (xn / xc) * maxT;
-            fn = fs[i] = pdf(xn);
-            xScaled[i] = xn / maxT;
-            xc = xn;
-        }
-    }
-
-    /// samples a value from the discrete distribution
-    T opCall() const
-    {
-        import std.random : rndGen;
-        return opCall(rndGen);
-    }
-
-    /// samples a value from the discrete distribution using a custom random generator
-    T opCall(RNG)(ref RNG gen) const
-        if (typeof(gen.front).sizeof == UIntType.sizeof)
-    {
-        import std.random : uniform;
-        import std.traits : Signed;
-        import std.range : ElementType;
-        import std.math : abs;
-
-        // TODO: option for inlining
-        for (;;)
-        {
-            static if (bothSides)
-                Signed!(ElementType!RNG) u = gen.front;
-            else
-                auto u = gen.front;
-
-            gen.popFront();
-
-            // TODO: this is a bit biased
-            size_t i = u & kMask;
-            //size_t i = uniform!("[)", size_t, size_t)(0, kMask, gen);
-
-            // U * x_i < x_{i+1}
-            static if (bothSides)
-            {
-                if (abs(u) < xDiv[i])
-                    return u * xScaled[i];
-            }
-            else
-            {
-                if (u < xDiv[i])
-                    return u * xScaled[i];
-            }
-
-            if (i == 0)
-            {
-                // generate x from tail block
-                static if (bothSides)
-                    return fallback(u > 0, gen);
-                else
-                    return fallback(gen);
-            }
-            else
-            {
-                auto x = u * xScaled[i];
-                if (fs[i] + u * (fs[i - 1] - fs[i]) < pdf(x))
-                    return x;
-            }
-        }
-    }
-
-private:
-    mixin(_fallback);
 }

--- a/benchmarks/flex/normal_dist.d
+++ b/benchmarks/flex/normal_dist.d
@@ -1,0 +1,326 @@
+#!/usr/bin/env dub
+/+ dub.json:
+{
+    "name": "bench_flex_normal",
+    "dependencies": {
+        "mir": {"path":"../.."},
+        "hap": "1.0.0-rc.2.1",
+        "dstats": "1.0.3",
+        "atmosphere": "0.1.7"
+    },
+    "dflags-ldc": ["-mcpu=native"]
+}
++/
+/+
+$ ldc-git --version
+LDC - the LLVM D compiler (798cda):
+  based on DMD v2.071.2-b1 and LLVM 3.8.1
+  built with DMD64 D Compiler v2.071.1
+  Default target: x86_64-unknown-linux-gnu
+  Host CPU: haswell
+  http://dlang.org - http://wiki.dlang.org/LDC
+
+$ dub run --build=release-nobounds --compiler=ldmd2-git --single benchmarks/flex/normal_dist.d
+
+boxMueller.naive   = 12 secs, 36 ms, and 998 μs
+boxMueller.hap     = 40 secs, 844 ms, 230 μs, and 6 hnsecs
+boxMueller.dstats  = 8 secs, 4 ms, 556 μs, and 4 hnsecs
+flexNormal.slow    = 14 secs, 54 ms, 592 μs, and 4 hnsecs
+flexNormal.medium  = 12 secs, 13 ms, 252 μs, and 9 hnsecs
+flexNormal.fast    = 11 secs, 174 ms, 573 μs, and 5 hnsecs
+ziggurat           = 3 secs, 538 ms, 75 μs, and 9 hnsecs
++/
+
+import mir.random.flex;
+
+/*
+$(WEB https://en.wikipedia.org/wiki/Box%E2%80%93Muller_transform, Box Muller-transform)
+References:
+    Butcher, J. C. "Random sampling from the normal distribution."
+    The Computer Journal 3.4 (1961): 251-253.
+    http://comjnl.oxfordjournals.org/content/3/4/251.full.pdf
+*/
+auto boxMueller(S, RNG)(S mu, S sigma, ref RNG gen)
+{
+    import mir.internal.math : log, cos, sin, sqrt;
+    import std.math : PI;
+    import std.random : uniform;
+
+    static S epsilon = S.min_normal;
+	static S two_pi = 2.0 * PI;
+
+	static S z0, z1;
+	static bool generate;
+	generate = !generate;
+
+	if (!generate)
+	   return z1 * sigma + mu;
+
+	S u1, u2;
+	do
+	{
+	   u1 = uniform(0.0L, 1.0L, gen);
+	   u2 = uniform(0.0L, 1.0L, gen);
+	}
+	while (u1 <= epsilon);
+
+	z0 = sqrt(-2.0 * log(u1)) * cos(two_pi * u2);
+	z1 = sqrt(-2.0 * log(u1)) * sin(two_pi * u2);
+	return z0 * sigma + mu;
+}
+
+auto genNormal(S)(S rho = 1.1)
+{
+    import std.math : exp, log, PI, sqrt;
+    S[] points = [-S.infinity, -1.5, 0, 1.5, S.infinity];
+    enum S halfLog2PI = S(0.5) * log(2 * PI);
+    auto f0 = (S x) => -(x * x) * S(0.5) - halfLog2PI;
+    auto f1 = (S x) => -x;
+    auto f2 = (S x) => S(-1);
+    return flex(f0, f1, f2, -0.5, points, rho);
+}
+
+__gshared float r = 0.0;
+
+void main()
+{
+    import std.datetime: benchmark, Duration;
+    import std.stdio : writefln;
+    import std.conv : to;
+
+    alias S = double;
+
+    auto flexNormalSlow = genNormal!S(1.3);
+    auto flexNormalMedium = genNormal!S(1.1);
+    auto flexNormalFast = genNormal!S(1.0001);
+
+    auto zigguratNormal = normal!(S, uint)();
+
+    // just pick any rng gen, it will have the same speed for all algorithms
+    import std.random : Mt19937;
+    auto gen = Mt19937(42);
+
+
+    auto bench = benchmark!(
+        { r += boxMueller!S(0, 1, gen); },
+        {
+            import hap.random.distribution : normal;
+            r += normal(0, 1, gen);
+        },
+        {
+            import dstats.random : rNorm;
+            r += rNorm(S(0), S(1), gen);
+        },
+        {
+            import atmosphere.random : rNormal;
+            r += rNormal!S(gen);
+        },
+        { r += flexNormalSlow(gen); },
+        { r += flexNormalMedium(gen); },
+        { r += flexNormalFast(gen); },
+        { r += zigguratNormal(gen); },
+    )(1_000_000);
+
+    string[] names = ["boxMueller.naive", "boxMueller.hap", "boxMueller.dstats",
+                      "boxMueller.atmos",
+                      "flexNormal.slow", "flexNormal.medium",
+                      "flexNormal.fast", "ziggurat"];
+
+    foreach(j,r;bench)
+        writefln("%-18s = %s", names[j], r.to!Duration);
+}
+
+
+
+// the ziggurat implementation is WIP, as dub doesn't support pure git modules yet,
+// it was just copied over here
+
+
+
+
+import std.traits : isNumeric;
+
+/**
+Setup a _normal distribution sampler.
+
+Params:
+    T = floating-point type that should be sampled
+    UIntType = unsigned UIntType of the random generator
+
+Returns:
+    A $(LREF Ziggurat) sampler that can be called to sample from the distribution.
+*/
+auto normal(T, UIntType = uint)()
+{
+    import mir.internal.math : exp, log, sqrt;
+
+    auto pdf    = (T x) => cast(T) exp(T(-0.5) * x * x);
+    auto invPdf = (T x) => cast(T) sqrt(T(-2) * log(x));
+
+    // values from [Marsaglia00]
+    T rightEnd = 3.442619855899;
+
+    /// generate x for the last block (aka tail-block)
+    enum fallback = q{
+        T fallback(RNG)(bool isPositive, ref RNG gen) const
+        {
+            import std.random : uniform;
+            import std.math : log;
+            T x, y, u;
+            do
+            {
+                u = uniform!("[]", T, T)(0, 1, gen);
+                x = -log(u) / fs[$ - 1];
+                u = uniform!("[]", T, T)(0, 1, gen);
+                y = -log(u);
+            }
+            while (y + y < x * x);
+            return isPositive ? rightEnd + x : -rightEnd - x;
+        }
+    };
+
+    return Ziggurat!(T, fallback, UIntType, 128, true)(pdf, invPdf, rightEnd, T(9.91256303526217e-3));
+}
+
+/**
+Ziggurat algorithm for generating a random variable from a montone, decreasing density.
+
+Complexity: O_avg: O(1)
+
+References:
+    Marsaglia, George, and Wai Wan Tsang. "The ziggurat method for generating random variables."
+    Journal of statistical software 5.8 (2000): 1-7.
+*/
+struct Ziggurat(T, string _fallback, UIntType, size_t numberOfBlocks, bool bothSides)
+    if (isNumeric!T)
+{
+
+private:
+
+    /// monotone decreasing probability density function
+    /// constants don't matter
+    T function(T x) pdf;
+    T function(T x) invPdf;
+
+    /// precalculate difference x_i / x_{i+1}
+    T[numberOfBlocks] xDiv;
+    /// precalculate scaling to R.max for x_i
+    T[numberOfBlocks] xScaled;
+    /// precalculate pdf value for x_i
+    T[numberOfBlocks] fs;
+
+    // mask to use to get the first log_2 k bits (=k - 1)
+    enum size_t kMask = numberOfBlocks - 1;
+
+    /// left-point of the right-most block
+    T rightEnd;
+
+    /// area of every column
+    T blockArea;
+
+public:
+    /**
+    Params:
+        pdf = probability density function
+        invPdf = inverse probability density function
+        rightEnd = left point of the right-most block
+        blockArea =  area of every column
+    */
+    this(T function(T x) pdf, T function(T x) invPdf, T rightEnd, T blockArea)
+    {
+        this.pdf = pdf;
+        this.invPdf = invPdf;
+        this.rightEnd = rightEnd;
+        this.blockArea = blockArea;
+
+        // scale factor to the range of UIntType
+        T maxT = bothSides ? UIntType.max / 2 : UIntType.max;
+
+        auto xn = rightEnd; // Next x_{i+1}
+        auto xc = xn; // Current x_i
+        auto fn = pdf(xn);
+
+        // k_i = floor(2^32 (x_{i-1} / x_i))
+        xDiv[0] = (xn * fn / blockArea) * maxT;
+        xDiv[1] = 0;
+
+        // w_i = 0.5^32 * x_i
+        xScaled[0]     = (blockArea / fn) / maxT;
+        xScaled[$ - 1] = xn / maxT;
+
+        // f_i = f(x_i)
+        fs[0]     = T(1);
+        fs[$ - 1] = fn;
+
+        for (auto i = xScaled.length - 2; i >= 1; i--)
+        {
+            xn = invPdf(blockArea / xn + fn);
+            xDiv[i + 1] = (xn / xc) * maxT;
+            fn = fs[i] = pdf(xn);
+            xScaled[i] = xn / maxT;
+            xc = xn;
+        }
+    }
+
+    /// samples a value from the discrete distribution
+    T opCall() const
+    {
+        import std.random : rndGen;
+        return opCall(rndGen);
+    }
+
+    /// samples a value from the discrete distribution using a custom random generator
+    T opCall(RNG)(ref RNG gen) const
+        if (typeof(gen.front).sizeof == UIntType.sizeof)
+    {
+        import std.random : uniform;
+        import std.traits : Signed;
+        import std.range : ElementType;
+        import std.math : abs;
+
+        // TODO: option for inlining
+        for (;;)
+        {
+            static if (bothSides)
+                Signed!(ElementType!RNG) u = gen.front;
+            else
+                auto u = gen.front;
+
+            gen.popFront();
+
+            // TODO: this is a bit biased
+            size_t i = u & kMask;
+            //size_t i = uniform!("[)", size_t, size_t)(0, kMask, gen);
+
+            // U * x_i < x_{i+1}
+            static if (bothSides)
+            {
+                if (abs(u) < xDiv[i])
+                    return u * xScaled[i];
+            }
+            else
+            {
+                if (u < xDiv[i])
+                    return u * xScaled[i];
+            }
+
+            if (i == 0)
+            {
+                // generate x from tail block
+                static if (bothSides)
+                    return fallback(u > 0, gen);
+                else
+                    return fallback(gen);
+            }
+            else
+            {
+                auto x = u * xScaled[i];
+                if (fs[i] + u * (fs[i - 1] - fs[i]) < pdf(x))
+                    return x;
+            }
+        }
+    }
+
+private:
+    mixin(_fallback);
+}

--- a/circle.yml
+++ b/circle.yml
@@ -40,7 +40,7 @@ test:
     - sed 's/"to_be_filled"/"Flex_logging", "Flex_logging_hex"/' -i dub.json
     - dub build --single examples/lda_hoffman_sparse.d
     # workaround against dub bugs
-    - dub fetch imageformats && dub build imageformats
+    - dub fetch imageformats --version 6.0.0 && dub build imageformats
     - dub build --single examples/median_filter.d
     - dub build --single examples/means_of_columns.d
     # Build Flex plots

--- a/examples/flex_plot/flex_common/flex_common/hatsqueeze.d
+++ b/examples/flex_plot/flex_common/flex_common/hatsqueeze.d
@@ -120,12 +120,15 @@ auto npPlotHatAndSqueeze(S, Pdf)(in FlexInterval!S[] intervals, Pdf pdf,
 
     pythonContext.fileName = fileName;
     pythonContext.title = title;
+    pythonContext.xmin = left;
+    pythonContext.xmax = right;
     pythonContext.py_stmts(`
         import matplotlib.pyplot as plt
         import numpy as np
     `);
     scope(exit) pythonContext.py_stmts(`
         plt.title(title)
+        plt.xlim(xmin, xmax)
         plt.savefig(fileName, bbox_inches='tight', format="pdf")
         plt.close()
     `);

--- a/examples/flex_plot/flex_common/flex_common/package.d
+++ b/examples/flex_plot/flex_common/flex_common/package.d
@@ -5,6 +5,8 @@ shared static this() {
     py_init();
 }
 
+public import flex_common.hist;
+
 /**
 CFlex glues the Flex algorithm to plotting code and allows to visualize
 the resulting distribution and its hat and squeeze plots.
@@ -125,12 +127,12 @@ struct CFlex(S)
                 hc.histType = histType;
 
                 if (plotHistogram)
-                    pdf.npPlotHistogram(values, fileName ~ "_hist.pdf", hc);
+                    pdf.histogram(values, fileName ~ "_hist.pdf", hc);
 
                 if (plotCumulativeHistogram)
                 {
                     hc.cumulative = true;
-                    pdf.npPlotHistogram(values, fileName ~ "_hist_cum.pdf", hc);
+                    pdf.histogram(values, fileName ~ "_hist_cum.pdf", hc);
                 }
             }
 

--- a/examples/median_filter.d
+++ b/examples/median_filter.d
@@ -2,7 +2,7 @@
 /+ dub.sdl:
 name "median_filter"
 dependency "mir" path=".."
-dependency "imageformats" version="~>6.0.0"
+dependency "imageformats" version="==6.0.0"
 +/
 
 import mir.ndslice;

--- a/source/mir/random/flex/internal/area.d
+++ b/source/mir/random/flex/internal/area.d
@@ -464,26 +464,28 @@ body
                 area /= sh.slope;
 
                 version(X86_64)
-                if (iv.c > 0)
                 {
-                    import std.math : pow;
-                    import std.math : approxEqual, isFinite;
-                    S p = (iv.c + 1) / iv.c;
-                    S val = (iv.c * leftOrRight) / (sh.slope * (iv.c + 1)) *
-                            (pow(sh.a + sh.slope * leftOrRight * ivLength, p) - pow(sh.a, p));
+                    if (iv.c > 0)
+                    {
+                        import std.math : pow;
+                        import std.math : approxEqual, isFinite;
+                        S p = (iv.c + 1) / iv.c;
+                        S val = (iv.c * leftOrRight) / (sh.slope * (iv.c + 1)) *
+                                (pow(sh.a + sh.slope * leftOrRight * ivLength, p) - pow(sh.a, p));
 
-                    assert(approxEqual(area, val));
-                }
-                else
-                {
-                    import std.math : sgn, pow;
-                    import std.math : approxEqual, isFinite;
-                    S p = (iv.c + 1) / iv.c;
-                    S sgnC = sgn(iv.c);
-                    S val = (iv.c * leftOrRight * sgnC) / (sh.slope * (iv.c + 1)) *
-                            (pow(sgnC * (sh.a + sh.slope * leftOrRight * ivLength), p) - pow(sgnC * sh.a, p));
+                        assert(approxEqual(area, val));
+                    }
+                    else
+                    {
+                        import std.math : sgn, pow;
+                        import std.math : approxEqual, isFinite;
+                        S p = (iv.c + 1) / iv.c;
+                        S sgnC = sgn(iv.c);
+                        S val = (iv.c * leftOrRight * sgnC) / (sh.slope * (iv.c + 1)) *
+                                (pow(sgnC * (sh.a + sh.slope * leftOrRight * ivLength), p) - pow(sgnC * sh.a, p));
 
-                    assert(approxEqual(area, val));
+                        assert(approxEqual(area, val));
+                    }
                 }
             }
         }

--- a/source/mir/random/flex/internal/area.d
+++ b/source/mir/random/flex/internal/area.d
@@ -463,6 +463,7 @@ body
                 area = r - l;
                 area /= sh.slope;
 
+                version(X86_64)
                 if (iv.c > 0)
                 {
                     import std.math : pow;

--- a/source/mir/random/flex/internal/area.d
+++ b/source/mir/random/flex/internal/area.d
@@ -344,6 +344,9 @@ body
             t += 1 + z * S(0.5) + (z * z) * one_div_6;
             area *= t;
             area *= ivLength;
+            // TODO: this should be
+            //area *= leftOrRight;
+            //area /= iv.slope;
         }
         else
         {
@@ -380,13 +383,15 @@ body
             if (fabs(z) < S(0.5))
             {
                 area = 1 / (sh.a * sh.a) * ivLength / (z + 1);
+
+                // TODO - equivalent to
+                S area3 = (ivLength) / (sh.a * sh.a + sh.a * sh.slope * leftOrRight * ivLength);
             }
             else
             {
                 S _l = 1 / shL;
                 S _r = 1 / shR;
                 area = (_l - _r) / sh.slope;
-
                 import std.math : approxEqual, isFinite;
 
                 if (area.isFinite && ivLength.isFinite)
@@ -401,6 +406,12 @@ body
                 area = 1 - z * S(0.5) + z * z * one_div_3;
                 area *=  -ivLength;
                 area /= sh.a;
+
+                // TODO: why don't we use this trick?
+                //auto shc = sh;
+                //sh.slope = 0.0001;
+                //S area4 = -log(-sh.a - sh.slope * leftOrRight * ivLength ) + log(-sh.a);
+                //area4 /= sh.slope * leftOrRight;
             }
             else
             {
@@ -428,6 +439,21 @@ body
                 assert(sh.a * sgn(iv.c) >= 0);
                 area = flexInverse!true(sh.a, iv.c);
                 area *= ivLength;
+
+                // TODO: why can't we simply set slope = 0.0001 here?
+                //if (iv.c > 0)
+                //{
+                    //import std.math : pow;
+                    //import std.math : approxEqual, isFinite;
+                    //S p = (iv.c + 1) / iv.c;
+                    //auto shC = sh;
+                    //shC.slope = 0.0001;
+                    //S val = (iv.c * leftOrRight) / (shC.slope * (iv.c + 1)) *
+                            //(pow(sh.a + shC.slope * leftOrRight * ivLength, p) - pow(sh.a, p));
+                    //import std.stdio;
+                    //writefln("val: %.10f", val);
+                    //writefln("area: %.10f", area);
+                //}
             }
             else
             {

--- a/source/mir/random/flex/internal/area.d
+++ b/source/mir/random/flex/internal/area.d
@@ -416,15 +416,6 @@ body
                 S val = -log(-sh.a - sh.slope * leftOrRight * ivLength ) + log(-sh.a);
                 val /= sh.slope * leftOrRight;
                 import std.math : approxEqual, isFinite;
-                scope(failure) {
-                    import std.stdio;
-                    writeln("sigma", leftOrRight);
-                    writeln("sh", sh);
-                    writeln("l", iv.lx);
-                    writeln("r", iv.rx);
-                    writeln("area", area);
-                    writeln("val", val);
-                }
                 if (area.isFinite)
                     assert(approxEqual(area, val));
             }
@@ -445,6 +436,28 @@ body
                 S l = antiderivative!true(shL, iv.c);
                 area = r - l;
                 area /= sh.slope;
+
+                if (iv.c > 0)
+                {
+                    import std.math : pow;
+                    import std.math : approxEqual, isFinite;
+                    S p = (iv.c + 1) / iv.c;
+                    S val = (iv.c * leftOrRight) / (sh.slope * (iv.c + 1)) *
+                            (pow(sh.a + sh.slope * leftOrRight * ivLength, p) - pow(sh.a, p));
+
+                    assert(approxEqual(area, val));
+                }
+                else
+                {
+                    import std.math : sgn, pow;
+                    import std.math : approxEqual, isFinite;
+                    S p = (iv.c + 1) / iv.c;
+                    S sgnC = sgn(iv.c);
+                    S val = (iv.c * leftOrRight * sgnC) / (sh.slope * (iv.c + 1)) *
+                            (pow(sgnC * (sh.a + sh.slope * leftOrRight * ivLength), p) - pow(sgnC * sh.a, p));
+
+                    assert(approxEqual(area, val));
+                }
             }
         }
     }

--- a/source/mir/random/flex/internal/area.d
+++ b/source/mir/random/flex/internal/area.d
@@ -335,6 +335,12 @@ body
         {
             area = exp(shR) - exp(shL);
             area /= sh.slope;
+
+            // according to own math
+            import std.math : approxEqual, isNaN;
+            if (!area.isNaN)
+                assert(area.approxEqual(
+                    leftOrRight * exp(sh.a) / sh.slope * (exp(leftOrRight * sh.slope * ivLength) - 1)));
         }
     }
     else
@@ -350,6 +356,10 @@ body
             area = S(0.5) * sh.a * ivLength;
             S t = z + 2;
             area *= t;
+
+            // according to own math
+            import std.math : approxEqual;
+            assert(approxEqual(area, ivLength * (sh.a + leftOrRight * S(0.5) * sh.slope * ivLength)));
         }
         else if (iv.c == S(-0.5))
         {

--- a/source/mir/random/flex/package.d
+++ b/source/mir/random/flex/package.d
@@ -142,7 +142,7 @@ auto flex(S, F0, F1, F2)
                 S[] cs, S[] points, S rho = 1.1, int maxApproxPoints = 1_000)
     if (isFloatingPoint!S)
 {
-    import mir.internal.math: exp;
+    import mir.internal.math : exp;
     auto pdf = (S x) => exp(f0(x));
     return flex(pdf, flexIntervals(f0, f1, f2, cs, points, rho, maxApproxPoints));
 }
@@ -194,8 +194,10 @@ struct Flex(S, Pdf)
         foreach (el; intervals.map!`a.hatArea`)
             total += el;
 
+        S totalSum = total.sum;
+
         foreach (i, ref cd; cdPoints)
-            cd = intervals[i].hatArea / total.sum;
+            cd = intervals[i].hatArea / totalSum;
 
         this.ds = Discrete!S(cdPoints);
     }

--- a/source/mir/utility/linearfun.d
+++ b/source/mir/utility/linearfun.d
@@ -114,7 +114,7 @@ struct LinearFun(S)
     }
 
     ///
-    version(Flex_logging) string logHex()
+    string logHex()
     {
         import std.format : format;
         return "LinearFun!%s(%a, %a, %a)".format(S.stringof, slope, y, a);


### PR DESCRIPTION
Hi @9il @joseph-wakeling-sociomantic @WebDrake

As the (Tin)flex algorithm is about to go into its final stage (@WebDrake see e.g. #286 and #281), I did a quick performance benchmark across existing tools. Note that this is benchmark assumes that all samplers return distributions with "good random quality", but assessing that will be another benchmark.

1) `flexNormal` isn't the fastest as it needs at least three random variables (in their C code the author manage to [reuse one](https://github.com/cran/Tinflex/blob/master/src/Tinflex.c#L218) of them, but I am currently not a huge fan of leaking such details from the new Alias method sampler), however the point of the (tin)flex algorithm isn't to be the fastest sampler, but to allow easy construction of new distributions. That being said we should of course try to squeeze the last wasted cycles out of it.
2) I hope it shows how valuable Ziggurat is/will be (>3x faster & there's still space for further optimizations)

About the benchmark itself:
- as the rest of mir it requires the latest `ldc` (> 1.0.0)
- the values below sampled 10M values, but the default (1M) works fine to show the differences as well
- @WebDrake I don't know why `hap` is so slow, but I guess it's due to `uniform01`
- the three different versions of the flex algorithm use different `rho` and thus higher/lower efficiency (-> number of times it needs to resample for one value)

```
dub run --build=release-nobounds --compiler=ldmd2-git --single benchmarks/flex/normal_dist.d 
```

```
boxMueller.naive   = 1 sec, 379 ms, 411 μs, and 3 hnsecs
boxMueller.hap     = 23 secs, 568 ms, 35 μs, and 4 hnsecs
boxMueller.dstats  = 1 sec, 217 ms, 655 μs, and 3 hnsecs
boxMueller.atmos   = 2 secs, 113 ms, 476 μs, and 1 hnsec
flexNormal.slow    = 2 secs, 460 ms, 365 μs, and 9 hnsecs
flexNormal.medium  = 2 secs, 151 ms, 805 μs, and 3 hnsecs
flexNormal.fast    = 2 secs, 27 ms, 822 μs, and 1 hnsec
ziggurat           = 423 ms, 150 μs, and 9 hnsecs
```

Just in case here are the links to the other packages
- [dstats](https://github.com/DlangScience/dstats/blob/master/source/dstats/distrib.d)
- [hap](https://github.com/WebDrake/hap/blob/master/source/hap/random/distribution.d)
- [atmosphere](https://github.com/9il/atmosphere/blob/master/source/atmosphere/random.d)
- [Ziggurat](https://github.com/libmir/mir/pull/261)
