### PR TITLE
Added ndslice algorithm benchmarks

### DIFF
--- a/benchmarks/ndslice/binarization.d
+++ b/benchmarks/ndslice/binarization.d
@@ -28,7 +28,7 @@ import std.algorithm.comparison : min;
 import mir.ndslice;
 import mir.ndslice.internal : fastmath;
 
-alias F = float;
+alias F = double;
 
 void binarizationLockstep(Slice!(2, F*) input, F threshold, Slice!(2, F*) output)
 {

--- a/benchmarks/ndslice/binarization.d
+++ b/benchmarks/ndslice/binarization.d
@@ -30,22 +30,22 @@ import mir.ndslice.internal : fastmath;
 
 alias F = float;
 
-void binarizationLockstep(Slice!(2, F*) input, F binarization, Slice!(2, F*) output)
+void binarizationLockstep(Slice!(2, F*) input, F threshold, Slice!(2, F*) output)
 {
     import std.range : lockstep;
     foreach(i, ref o; lockstep(input.byElement, output.byElement))
     {
-        o = (i > binarization) ? F(1) : F(0);
+        o = (i > threshold) ? F(1) : F(0);
     }
 }
 
-void binarizationAssumeSameStructure(Slice!(2, F*) input, F binarization, Slice!(2, F*) output)
+void binarizationAssumeSameStructure(Slice!(2, F*) input, F threshold, Slice!(2, F*) output)
 {
     import mir.ndslice.algorithm : ndEach;
     import mir.ndslice.slice : assumeSameStructure;
 
     assumeSameStructure!("input", "output")(input, output).ndEach!( (p) {
-        p.output = (p.input > binarization) ? F(1) : F(0);
+        p.output = (p.input > threshold) ? F(1) : F(0);
     });
 }
 
@@ -53,7 +53,7 @@ void binarizationAssumeSameStructure(Slice!(2, F*) input, F binarization, Slice!
 __gshared n = 256; // image size
 __gshared Slice!(2, F*) a;
 __gshared Slice!(2, F*) b;
-__gshared F t; // binarization
+__gshared F t; // threshold
 
 void main()
 {

--- a/benchmarks/ndslice/binarization.d
+++ b/benchmarks/ndslice/binarization.d
@@ -1,7 +1,7 @@
 #!/usr/bin/env dub
 /+ dub.json:
 {
-    "name": "dot_product",
+    "name": "binarization",
     "dependencies": {"mir": {"path":"../.."}},
     "dflags-ldc": ["-mcpu=native"]
 }

--- a/benchmarks/ndslice/binarization.d
+++ b/benchmarks/ndslice/binarization.d
@@ -57,11 +57,9 @@ __gshared F t; // threshold
 
 void main()
 {
-    import std.random : uniform;
-
-    a = iotaSlice(n, n).mapSlice!(v => v.to!F).slice;
+    a = iotaSlice(n, n).as!F.slice;
     b = a.slice;
-    t = uniform(F(0), F(n*n));
+    t = n * n / 2;
 
     Duration[2] bestBench = Duration.max;
 

--- a/benchmarks/ndslice/binarization.d
+++ b/benchmarks/ndslice/binarization.d
@@ -1,0 +1,80 @@
+#!/usr/bin/env dub
+/+ dub.json:
+{
+    "name": "dot_product",
+    "dependencies": {"mir": {"path":"../.."}},
+    "dflags-ldc": ["-mcpu=native"]
+}
++/
+/+
+Benchmark demonstrates performance superiority of using mir.ndslice.slice.assumeSameStructure over
+std.range.lockstep, for multidimensional processing with ndslice package.
+
+$ ldc2 --version
+LDC - the LLVM D compiler (918073):
+  based on DMD v2.071.1 and LLVM 3.8.0
+  built with LDC - the LLVM D compiler (918073)
+  Default target: x86_64-apple-darwin15.6.0
+  Host CPU: haswell
+  http://dlang.org - http://wiki.dlang.org/LDC
+
+$ dub run --build=release-nobounds --compiler=ldmd2 --single binarization.d
++/
+import std.datetime : benchmark, Duration;
+import std.stdio : writefln;
+import std.conv : to;
+import std.algorithm.comparison : min;
+
+import mir.ndslice;
+import mir.ndslice.internal : fastmath;
+
+alias F = float;
+
+void binarizationLockstep(Slice!(2, F*) input, F binarization, Slice!(2, F*) output)
+{
+    import std.range : lockstep;
+    foreach(i, ref o; lockstep(input.byElement, output.byElement))
+    {
+        o = (i > binarization) ? F(1) : F(0);
+    }
+}
+
+void binarizationAssumeSameStructure(Slice!(2, F*) input, F binarization, Slice!(2, F*) output)
+{
+    import mir.ndslice.algorithm : ndEach;
+    import mir.ndslice.slice : assumeSameStructure;
+
+    assumeSameStructure!("input", "output")(input, output).ndEach!( (p) {
+        p.output = (p.input > binarization) ? F(1) : F(0);
+    });
+}
+
+// __gshared is used to prevent specialized optimization for input data
+__gshared n = 256; // image size
+__gshared Slice!(2, F*) a;
+__gshared Slice!(2, F*) b;
+__gshared F t; // binarization
+
+void main()
+{
+    import std.random : uniform;
+
+    a = iotaSlice(n, n).mapSlice!(v => v.to!F).slice;
+    b = a.slice;
+    t = uniform(F(0), F(n*n));
+
+    Duration[2] bestBench = Duration.max;
+
+    foreach (_; 0 .. 10)
+    {
+        auto bench = benchmark!(
+            { binarizationLockstep(a, t, b); },
+            { binarizationAssumeSameStructure(a, t, b); }
+        )(1_000);
+        foreach (i, ref b; bestBench)
+            b = min(bench[i].to!Duration, b);
+    }
+
+    writefln("%26s = %s", "lockstep", bestBench[0]);
+    writefln("%26s = %s", "assumeSameStructure", bestBench[1]);
+}

--- a/benchmarks/ndslice/convolution.d
+++ b/benchmarks/ndslice/convolution.d
@@ -78,7 +78,7 @@ __gshared Slice!(2, F*) k;
 
 void main()
 {
-    a = iotaSlice(n, n).mapSlice!(v => v.to!F).slice;
+    a = iotaSlice(n, n).as!F.slice;
     b = a.slice;
     k = iotaSlice(m, m).mapSlice!(v => F(1) / F(m * m)).slice;
 

--- a/benchmarks/ndslice/convolution.d
+++ b/benchmarks/ndslice/convolution.d
@@ -28,7 +28,7 @@ import std.algorithm.comparison : min;
 import mir.ndslice;
 import mir.ndslice.internal : fastmath;
 
-alias F = float;
+alias F = double;
 
 @fastmath void convLoop(Slice!(2, F*) input, Slice!(2, F*) output, Slice!(2, F*) kernel)
 {

--- a/benchmarks/ndslice/convolution.d
+++ b/benchmarks/ndslice/convolution.d
@@ -1,0 +1,99 @@
+#!/usr/bin/env dub
+/+ dub.json:
+{
+    "name": "dot_product",
+    "dependencies": {"mir": {"path":"../.."}},
+    "dflags-ldc": ["-mcpu=native"]
+}
++/
+/+
+Benchmark demonstrates performance superiority of using mir.ndslice.algorithm over looped code, for
+multidimensional processing with ndslice package.
+
+$ ldc2 --version
+LDC - the LLVM D compiler (918073):
+  based on DMD v2.071.1 and LLVM 3.8.0
+  built with LDC - the LLVM D compiler (918073)
+  Default target: x86_64-apple-darwin15.6.0
+  Host CPU: haswell
+  http://dlang.org - http://wiki.dlang.org/LDC
+
+$ dub run --build=release-nobounds --compiler=ldmd2 --single convolution.d
++/
+import std.datetime : benchmark, Duration;
+import std.stdio : writefln;
+import std.conv : to;
+import std.algorithm.comparison : min;
+
+import mir.ndslice;
+import mir.ndslice.internal : fastmath;
+
+alias F = float;
+
+@fastmath void convLoop(Slice!(2, F*) input, Slice!(2, F*) output, Slice!(2, F*) kernel)
+{
+    auto kr = kernel.length!0; // kernel row size
+    auto kc = kernel.length!1; // kernel column size
+    foreach (r; 0 .. output.length!0)
+        foreach (c; 0 .. output.length!1)
+        {
+            // take window to input at given pixel coordinate
+            Slice!(2, F*) window = input[r .. r + kr, c .. c + kc];
+
+            // calculate result for current pixel
+            F v = 0.0f;
+            foreach (cr; 0 .. kr)
+                foreach (cc; 0 .. kc)
+                    v += window[cr, cc] * kernel[cr, cc];
+            output[r, c] = v;
+        }
+}
+
+static @fastmath F kapply(F v, F e, F k) @safe @nogc nothrow pure
+{
+    return v + (e * k);
+}
+
+void convAlgorithm(Slice!(2, F*) input, Slice!(2, F*) output, Slice!(2, F*) kernel)
+{
+    import mir.ndslice.algorithm : ndReduce, Yes;
+    import mir.ndslice.selection : windows, mapSlice;
+
+    auto mapping = input
+        // look at each pixel through kernel-sized window
+        .windows(kernel.shape)
+        // map each window to resulting pixel using convolution function
+        .mapSlice!((window) { return ndReduce!(kapply, Yes.vectorized)(0.0f, window, kernel); });
+
+    // assign mapped results to the output buffer.
+    output[] = mapping[];
+}
+
+// __gshared is used to prevent specialized optimization for input data
+__gshared n = 256; // image size
+__gshared m = 5; // kernel size
+__gshared Slice!(2, F*) a;
+__gshared Slice!(2, F*) b;
+__gshared Slice!(2, F*) k;
+
+void main()
+{
+    a = iotaSlice(n, n).mapSlice!(v => v.to!F).slice;
+    b = a.slice;
+    k = iotaSlice(m, m).mapSlice!(v => F(1) / F(m * m)).slice;
+
+    Duration[2] bestBench = Duration.max;
+
+    foreach (_; 0 .. 10)
+    {
+        auto bench = benchmark!(
+            { convLoop(a, b, k); },
+            { convAlgorithm(a, b, k); }
+        )(100);
+        foreach (i, ref b; bestBench)
+            b = min(bench[i].to!Duration, b);
+    }
+
+    writefln("%26s = %s", "loops", bestBench[0]);
+    writefln("%26s = %s", "mir.ndslice.algorithm", bestBench[1]);
+}

--- a/benchmarks/ndslice/convolution.d
+++ b/benchmarks/ndslice/convolution.d
@@ -1,7 +1,7 @@
 #!/usr/bin/env dub
 /+ dub.json:
 {
-    "name": "dot_product",
+    "name": "convolution",
     "dependencies": {"mir": {"path":"../.."}},
     "dflags-ldc": ["-mcpu=native"]
 }


### PR DESCRIPTION
Added benchmarks for referencing from blog post on `mir.ndslice.algorithm`. I have tried following style of existing benchmarks. Please let me know if you'd like it organized differently, or if there's anything we could improve in the code.

Iteration counts for benchmarks have been modified to stay in reasonable execution time frame.

Here are the results on my machine:
```
$ dub run --build=release-nobounds --compiler=ldmd2 --single binarization.d
Running ./binarization
                  lockstep = 169 ms, 871 μs, and 4 hnsecs
       assumeSameStructure = 39 ms, 105 μs, and 9 hnsecs
```
```
$ dub run --build=release-nobounds --compiler=ldmd2 --single convolution.d
Running ./convolution
                     loops = 4 secs, 857 ms, 601 μs, and 3 hnsecs
     mir.ndslice.algorithm = 153 ms, 100 μs, and 7 hnsecs
```

What worries me is if I remove `mcpu=native` flag, I get different results in the convolution benchmark:
```
Running ./convolution
                     loops = 1 sec, 649 ms, 99 μs, and 6 hnsecs
     mir.ndslice.algorithm = 159 ms, 392 μs, and 9 hnsecs
```

What exactly could be going on here?

