### PR TITLE
fix deprecated messages from std.experimental.ndslice in DMD2.073

### DIFF
--- a/source/mir/ndslice/algorithm.d
+++ b/source/mir/ndslice/algorithm.d
@@ -142,18 +142,18 @@ private template naryFun(bool hasSeed, size_t argCount, alias fun)
     }
 }
 
-static if (__VERSION__ < 2072)
-{
-    deprecated("please use mir.ndslice.selection.mapSlice instead.")
-    import mir.ndslice.selection : mapSlice;
-    deprecated("please use mir.ndslice.selection.mapSlice instead.")
-    public alias ndMap = mapSlice;
-}
-else
+static if (__VERSION__ == 2072)
 {
     deprecated("please use std.experimental.ndslice.selection.mapSlice instead.")
     import std.experimental.ndslice.selection : mapSlice;
     deprecated("please use std.experimental.ndslice.selection.mapSlice instead.")
+    public alias ndMap = mapSlice;
+}
+else // (__VERSION__ < 2072)
+{
+    deprecated("please use mir.ndslice.selection.mapSlice instead.")
+    import mir.ndslice.selection : mapSlice;
+    deprecated("please use mir.ndslice.selection.mapSlice instead.")
     public alias ndMap = mapSlice;
 }
 

--- a/source/mir/ndslice/internal.d
+++ b/source/mir/ndslice/internal.d
@@ -1,6 +1,6 @@
 module mir.ndslice.internal;
 
-static if (__VERSION__ >= 2072)
+static if (__VERSION__ == 2072)
 {
     public import std.experimental.ndslice.internal;
 }

--- a/source/mir/ndslice/iteration.d
+++ b/source/mir/ndslice/iteration.d
@@ -98,7 +98,7 @@ T4=$(TR $(TDNW $(LREF $1)) $(TD $2) $(TD $3) $(TD $4))
 */
 module mir.ndslice.iteration;
 
-static if (__VERSION__ >= 2072)
+static if (__VERSION__ == 2072)
 {
     public import std.experimental.ndslice.iteration;
 }

--- a/source/mir/ndslice/package.d
+++ b/source/mir/ndslice/package.d
@@ -321,7 +321,7 @@ TDNW2 = <td class="donthyphenate nobr" rowspan="2">$0</td>
 */
 module mir.ndslice;
 
-static if (__VERSION__ >= 2072)
+static if (__VERSION__ == 2072)
 {
     public import std.experimental.ndslice;
     public import mir.ndslice.algorithm;

--- a/source/mir/ndslice/selection.d
+++ b/source/mir/ndslice/selection.d
@@ -55,7 +55,7 @@ T4=$(TR $(TDNW $(LREF $1)) $(TD $2) $(TD $3) $(TD $4))
 */
 module mir.ndslice.selection;
 
-static if (__VERSION__ >= 2072)
+static if (__VERSION__ == 2072)
 {
     public import std.experimental.ndslice.selection;
 }

--- a/source/mir/ndslice/slice.d
+++ b/source/mir/ndslice/slice.d
@@ -15,7 +15,7 @@ STD = $(TD $(SMALL $0))
 */
 module mir.ndslice.slice;
 
-static if (__VERSION__ >= 2072)
+static if (__VERSION__ == 2072)
 {
     public import std.experimental.ndslice.slice;
 }


### PR DESCRIPTION
When I update DMD from 2.072 to 2.073, I got many deprecation messages like
```
/home/karita/tool/dmd2/linux/bin64/../../src/phobos/std/experimental/ndslice/package.d(315,15): 
Deprecation: module std.experimental.ndslice.slice is deprecated 
- Please use mir-algorithm DUB package: http://github.com/libmir/mir-algorithm
```
[log.txt](https://github.com/libmir/mir/files/732677/log.txt)



According to the messages, I rewrote the lines `import std.experimental.ndslice` to use mir modules.